### PR TITLE
차트 페이지 추가

### DIFF
--- a/src/pages/payment-list/components/daily-payment-list.tsx
+++ b/src/pages/payment-list/components/daily-payment-list.tsx
@@ -1,7 +1,6 @@
 import { CalendarIcon } from '@radix-ui/react-icons'
 import { Flex, IconButton, Text } from '@radix-ui/themes'
 import { Payment } from '~/queries/payment'
-import { dateFormat } from '~/utils/date'
 import { paymentAmountFormat } from '~/utils/units'
 import { ROUTE } from '~/router'
 import { useNavigate } from 'react-router-dom'
@@ -12,7 +11,7 @@ export const DailyPaymentList = ({ dailyPaymentList }: { dailyPaymentList: [stri
       {dailyPaymentList.map(([date, payments]) => (
         <Flex key={date} direction="column" gap="4" px="6">
           <Text size="1" color="gray">
-            {dateFormat(date)}
+            {date}
           </Text>
           <Flex direction="column" gap="4">
             {payments.map((payment) => (

--- a/src/pages/payment-list/hooks/use-payment-list-view-model.ts
+++ b/src/pages/payment-list/hooks/use-payment-list-view-model.ts
@@ -6,6 +6,7 @@ import { SORT_ORDER } from '~/constants/query'
 import { Payment, RequiredInfo, usePaymentsListQuery } from '~/queries/payment'
 import { toNumber } from '~/utils/number'
 import { getSumOfPayments } from '../services/getSumOfPayments'
+import { dateFormat } from '~/utils/date'
 
 export const usePaymentListViewModel = () => {
   const { year, month, day, dispatch: dispatchCalender } = useCalender()
@@ -28,7 +29,9 @@ export const usePaymentListViewModel = () => {
   )
 
   // Map을 배열로 변환합니다.
-  const dailyPaymentArray = dailyPaymentMap ? Array.from(dailyPaymentMap.entries()) : []
+  const dailyPaymentArray = dailyPaymentMap
+    ? Array.from(dailyPaymentMap.entries()).map(([date, payments]) => [dateFormat(date), payments])
+    : []
 
   const getDailyPayment = useCallback(
     ({ type, year, month, day }: Pick<RequiredInfo, 'type'> & DateState) => {

--- a/src/pages/statistics/components/donut-chart.tsx
+++ b/src/pages/statistics/components/donut-chart.tsx
@@ -1,0 +1,70 @@
+interface CoordsProps {
+  x: number // 원의 중심의 x 좌표
+  y: number // 원의 중심의 y 좌표
+  radius: number // 원의 반지름
+  degree: number // 원점에서 부터 호를 그릴 각도
+}
+
+interface ArcProps extends CoordsProps {
+  prevDegree: number
+}
+
+const getCoordsOnCircle = ({ x, y, radius, degree }: CoordsProps) => {
+  //원점, 회전각 => 끝 좌표 구하기
+  const radian = (degree / 180) * Math.PI
+  return { x: x + radius * Math.cos(radian), y: y + radius * Math.sin(radian) }
+}
+
+const getArc = ({ x, y, radius, prevDegree, degree }: ArcProps) => {
+  // 원점, 회전각 받음 => 끝 좌표 구해서 => 호 그리기
+  const startCoord = getCoordsOnCircle({ x, y, radius, degree: prevDegree })
+  const endCoord = getCoordsOnCircle({ x, y, radius, degree })
+  const isLargeArc = degree > 180 ? 0 : 1
+  const isEnd = degree === MAX_ANGLE
+  // A rx ry x축-회전각 큰-호-플래그 쓸기-방향-플래그 dx dy
+  const d = `
+    M ${startCoord.x} ${startCoord.y} 
+    A ${radius} ${radius}, 0, ${isLargeArc}, 1, ${endCoord.x} ${endCoord.y}
+  `
+  return d
+}
+
+const CENTER_X = 50
+const CENTER_Y = 50
+const RADIUS = 15
+const FULL_CIRCLE_DEGREES = 360
+const MAX_ANGLE = 359.9
+
+export const DonutChart = ({ data }) => {
+  const total = data.reduce((result, value) => result + value.amount, 0)
+  const accumulatedAngles = data.reduce(
+    (result, value, index) => {
+      const angle = (value.amount / total) * FULL_CIRCLE_DEGREES
+      const newAngle = result[index] + angle // 마지막 요소는 MAX_ANGLE로 설정
+      return [...result, newAngle]
+    },
+    [0]
+  )
+  return (
+    <svg width="500" height="500" viewBox="0 0 100 100">
+      {data.map((item, index, array) => {
+        console.log(accumulatedAngles)
+        return (
+          <path
+            key={index}
+            d={getArc({
+              x: CENTER_X,
+              y: CENTER_Y,
+              radius: RADIUS,
+              prevDegree: accumulatedAngles[index],
+              degree: accumulatedAngles[index + 1],
+            })}
+            stroke={`var(--accent-${11 - index})`}
+            strokeWidth={15}
+            fill="transparent"
+          />
+        )
+      })}
+    </svg>
+  )
+}

--- a/src/pages/statistics/components/donut-chart.tsx
+++ b/src/pages/statistics/components/donut-chart.tsx
@@ -9,6 +9,49 @@ interface ArcProps extends CoordsProps {
   prevDegree: number
 }
 
+const CENTER_X = 50
+const CENTER_Y = 50
+const RADIUS = 30
+const FULL_CIRCLE_DEGREES = 360
+const QUARTER_CIRCLE_DEGREES = 90
+
+interface DonutChartProps {
+  data: { amount: number }[]
+}
+
+export const DonutChart = ({ data }: DonutChartProps) => {
+  const total = data.reduce((result, value) => result + value.amount, 0)
+  const accumulatedAngles = data.reduce(
+    (result, value, index) => {
+      const angle = (value.amount / total) * FULL_CIRCLE_DEGREES
+      const newAngle = result[index] + angle
+      return [...result, newAngle]
+    },
+    [0]
+  )
+  return (
+    <svg width="300" height="300" viewBox="0 0 100 100">
+      {data.map((_, index) => {
+        return (
+          <path
+            key={index}
+            d={getArc({
+              x: CENTER_X,
+              y: CENTER_Y,
+              radius: RADIUS,
+              prevDegree: accumulatedAngles[index],
+              degree: accumulatedAngles[index + 1],
+            })}
+            stroke={`var(--accent-${11 - index})`}
+            strokeWidth={20}
+            fill="transparent"
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
 const getCoordsOnCircle = ({ x, y, radius, degree }: CoordsProps) => {
   //원점, 회전각 => 끝 좌표 구하기
   const radian = (degree / 180) * Math.PI
@@ -26,44 +69,4 @@ const getArc = ({ x, y, radius, prevDegree, degree }: ArcProps) => {
     A ${radius} ${radius}, 0, ${isLargeArc}, 1, ${endCoord.x} ${endCoord.y}
   `
   return d
-}
-
-const CENTER_X = 50
-const CENTER_Y = 50
-const RADIUS = 15
-const FULL_CIRCLE_DEGREES = 360
-const QUARTER_CIRCLE_DEGREES = 90
-
-export const DonutChart = ({ data }) => {
-  const total = data.reduce((result, value) => result + value.amount, 0)
-  const accumulatedAngles = data.reduce(
-    (result, value, index) => {
-      const angle = (value.amount / total) * FULL_CIRCLE_DEGREES
-      const newAngle = result[index] + angle
-      return [...result, newAngle]
-    },
-    [0]
-  )
-  return (
-    <svg width="500" height="500" viewBox="0 0 100 100">
-      {data.map((item, index, array) => {
-        console.log(accumulatedAngles)
-        return (
-          <path
-            key={index}
-            d={getArc({
-              x: CENTER_X,
-              y: CENTER_Y,
-              radius: RADIUS,
-              prevDegree: accumulatedAngles[index],
-              degree: accumulatedAngles[index + 1],
-            })}
-            stroke={`var(--accent-${11 - index})`}
-            strokeWidth={15}
-            fill="transparent"
-          />
-        )
-      })}
-    </svg>
-  )
 }

--- a/src/pages/statistics/components/donut-chart.tsx
+++ b/src/pages/statistics/components/donut-chart.tsx
@@ -42,7 +42,7 @@ export const DonutChart = ({ data }: DonutChartProps) => {
               prevDegree: accumulatedAngles[index],
               degree: accumulatedAngles[index + 1],
             })}
-            stroke={`var(--accent-${11 - index})`}
+            stroke={`var(--accent-${11 - index * 2})`}
             strokeWidth={20}
             fill="transparent"
           />
@@ -62,8 +62,8 @@ const getArc = ({ x, y, radius, prevDegree, degree }: ArcProps) => {
   // 원점, 회전각 받음 => 끝 좌표 구해서 => 호 그리기
   const startCoord = getCoordsOnCircle({ x, y, radius, degree: prevDegree - QUARTER_CIRCLE_DEGREES })
   const endCoord = getCoordsOnCircle({ x, y, radius, degree: degree - QUARTER_CIRCLE_DEGREES })
-  const isLargeArc = degree > 180 ? 0 : 1
-  // A rx ry x축-회전각 큰-호-플래그 쓸기-방향-플래그 dx dy
+  const isLargeArc = degree - prevDegree > 180 ? 1 : 0
+  // A rx ry, x축-회전각, 큰-호-플래그, 쓸기-방향-플래그, dx dy
   const d = `
     M ${startCoord.x} ${startCoord.y} 
     A ${radius} ${radius}, 0, ${isLargeArc}, 1, ${endCoord.x} ${endCoord.y}

--- a/src/pages/statistics/components/donut-chart.tsx
+++ b/src/pages/statistics/components/donut-chart.tsx
@@ -17,10 +17,9 @@ const getCoordsOnCircle = ({ x, y, radius, degree }: CoordsProps) => {
 
 const getArc = ({ x, y, radius, prevDegree, degree }: ArcProps) => {
   // 원점, 회전각 받음 => 끝 좌표 구해서 => 호 그리기
-  const startCoord = getCoordsOnCircle({ x, y, radius, degree: prevDegree })
-  const endCoord = getCoordsOnCircle({ x, y, radius, degree })
+  const startCoord = getCoordsOnCircle({ x, y, radius, degree: prevDegree - QUARTER_CIRCLE_DEGREES })
+  const endCoord = getCoordsOnCircle({ x, y, radius, degree: degree - QUARTER_CIRCLE_DEGREES })
   const isLargeArc = degree > 180 ? 0 : 1
-  const isEnd = degree === MAX_ANGLE
   // A rx ry x축-회전각 큰-호-플래그 쓸기-방향-플래그 dx dy
   const d = `
     M ${startCoord.x} ${startCoord.y} 
@@ -33,14 +32,14 @@ const CENTER_X = 50
 const CENTER_Y = 50
 const RADIUS = 15
 const FULL_CIRCLE_DEGREES = 360
-const MAX_ANGLE = 359.9
+const QUARTER_CIRCLE_DEGREES = 90
 
 export const DonutChart = ({ data }) => {
   const total = data.reduce((result, value) => result + value.amount, 0)
   const accumulatedAngles = data.reduce(
     (result, value, index) => {
       const angle = (value.amount / total) * FULL_CIRCLE_DEGREES
-      const newAngle = result[index] + angle // 마지막 요소는 MAX_ANGLE로 설정
+      const newAngle = result[index] + angle
       return [...result, newAngle]
     },
     [0]

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -2,10 +2,10 @@ import { DonutChart } from './components/donut-chart'
 
 export const Statistics = () => {
   const expenses = [
-    { category: '식비', amount: 300 },
-    { category: '기타', amount: 50 },
-    { category: '교통비', amount: 150 },
-    { category: '유흥비', amount: 100 },
+    { label: '식비', amount: 300 },
+    { label: '기타', amount: 50 },
+    { label: '교통비', amount: 150 },
+    { label: '유흥비', amount: 100 },
   ]
   return <DonutChart data={expenses} />
 }

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -1,11 +1,12 @@
 import { styled } from 'styled-components'
 import { DonutChart } from './components/donut-chart'
-import { Flex, Text } from '@radix-ui/themes'
+import { Flex, Section, Text } from '@radix-ui/themes'
 import { paymentAmountFormat } from '~/utils/units'
 import { Payment, usePaymentsListQuery } from '~/queries/payment'
 import { toNumber } from '~/utils/number'
 import { SORT_ORDER } from '~/constants/query'
 import { useMemo } from 'react'
+import { DailyPaymentList } from '../payment-list/components/daily-payment-list'
 
 export const Statistics = () => {
   const date = new Date()
@@ -25,6 +26,8 @@ export const Statistics = () => {
     [data]
   )
 
+  const categoryPaymentList = useMemo(() => Array.from(categoryPaymentMap.entries()), [categoryPaymentMap])
+
   const categoryTotalPayment = useMemo(() => {
     return Array.from(categoryPaymentMap.entries()).map(([category, payments]) => {
       const totalAmount = payments.reduce((sum, payment) => sum + payment.amount, 0)
@@ -35,19 +38,24 @@ export const Statistics = () => {
 
   const total = categoryTotalPayment.reduce((result, value) => result + value.amount, 0)
   return (
-    <Flex direction="column" align="center" gap="6">
-      <DonutChart data={categoryTotalPayment} />
-      <Flex direction="column" gap="2">
-        {categoryTotalPayment.map((item, index) => (
-          <Legend
-            key={item.label}
-            label={item.label}
-            color={`var(--accent-${11 - index * 2})`}
-            ratio={item.amount / total}
-            amount={item.amount}
-          />
-        ))}
+    <Flex justify="between" gap="9" height="calc(100dvh - 50px)">
+      <Flex width="50%" minWidth="300px" direction="column" align="center" gap="6">
+        <DonutChart data={categoryTotalPayment} />
+        <Flex direction="column" gap="2">
+          {categoryTotalPayment.map((item, index) => (
+            <Legend
+              key={item.label}
+              label={item.label}
+              color={`var(--accent-${11 - index * 2})`}
+              ratio={item.amount / total}
+              amount={item.amount}
+            />
+          ))}
+        </Flex>
       </Flex>
+      <Section width="50%" minWidth="300px">
+        <DailyPaymentList dailyPaymentList={categoryPaymentList} />
+      </Section>
     </Flex>
   )
 }

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components'
 import { DonutChart } from './components/donut-chart'
 import { Flex, Text } from '@radix-ui/themes'
+import { paymentAmountFormat } from '~/utils/units'
 
 export const Statistics = () => {
   const expenses = [
@@ -8,31 +9,50 @@ export const Statistics = () => {
     { label: '기타', amount: 50 },
     { label: '교통비', amount: 150 },
     { label: '유흥비', amount: 100 },
+    { label: '월세', amount: 100 },
   ]
+  const total = expenses.reduce((result, value) => result + value.amount, 0)
   expenses.sort((a, b) => b.amount - a.amount)
   return (
     <Flex direction="column" align="center" gap="6">
       <DonutChart data={expenses} />
       <Flex direction="column" gap="2">
         {expenses.map((item, index) => (
-          <Legend key={item.label} label={item.label} color={`var(--accent-${11 - index})`} />
+          <Legend
+            key={item.label}
+            label={item.label}
+            color={`var(--accent-${11 - index * 2})`}
+            ratio={item.amount / total}
+            amount={item.amount}
+          />
         ))}
       </Flex>
     </Flex>
   )
 }
 
-const Legend = ({ label, color }: { label: string; color: string }) => {
+const Legend = ({ label, color, ratio, amount }: { label: string; color: string; ratio: number; amount: number }) => {
+  const formattedRatio = `${(ratio * 100).toFixed(1)}%`
   return (
-    <Flex align="center" gap="2">
+    <Flex justify="start" align="center" gap="5" width="300px">
       <ColorBox color={color} />
-      <Text size="2">{label}</Text>
+      <Flex direction="column">
+        <Text size="3" weight="medium">
+          {label}
+        </Text>
+        <Text size="1" color="gray">
+          {formattedRatio}
+        </Text>
+      </Flex>
+      <Text weight="medium" ml="auto">
+        {paymentAmountFormat(amount, 'expense', 'full')}
+      </Text>
     </Flex>
   )
 }
 const ColorBox = styled.div`
-  width: 20px;
-  height: 20px;
-  border-radius: 2px;
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
   background-color: ${({ color }) => color};
 `

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -1,0 +1,11 @@
+import { DonutChart } from './components/donut-chart'
+
+export const Statistics = () => {
+  const expenses = [
+    { category: '식비', amount: 300 },
+    { category: '기타', amount: 50 },
+    { category: '교통비', amount: 150 },
+    { category: '유흥비', amount: 100 },
+  ]
+  return <DonutChart data={expenses} />
+}

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -1,4 +1,6 @@
+import { styled } from 'styled-components'
 import { DonutChart } from './components/donut-chart'
+import { Flex, Text } from '@radix-ui/themes'
 
 export const Statistics = () => {
   const expenses = [
@@ -7,5 +9,30 @@ export const Statistics = () => {
     { label: '교통비', amount: 150 },
     { label: '유흥비', amount: 100 },
   ]
-  return <DonutChart data={expenses} />
+  expenses.sort((a, b) => b.amount - a.amount)
+  return (
+    <Flex direction="column" align="center" gap="1">
+      <DonutChart data={expenses} />
+      <Flex direction="column" gap="2">
+        {expenses.map((item, index) => (
+          <Legend key={item.label} label={item.label} color={`var(--accent-${11 - index})`} />
+        ))}
+      </Flex>
+    </Flex>
+  )
 }
+
+const Legend = ({ label, color }: { label: string; color: string }) => {
+  return (
+    <Flex align="center" gap="2">
+      <ColorBox color={color} />
+      <Text size="2">{label}</Text>
+    </Flex>
+  )
+}
+const ColorBox = styled.div`
+  width: 20px;
+  height: 20px;
+  border-radius: 2px;
+  background-color: ${({ color }) => color};
+`

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -11,7 +11,7 @@ export const Statistics = () => {
   ]
   expenses.sort((a, b) => b.amount - a.amount)
   return (
-    <Flex direction="column" align="center" gap="1">
+    <Flex direction="column" align="center" gap="6">
       <DonutChart data={expenses} />
       <Flex direction="column" gap="2">
         {expenses.map((item, index) => (

--- a/src/queries/payment/payment.model.ts
+++ b/src/queries/payment/payment.model.ts
@@ -5,7 +5,7 @@ export const PAYMENTS_ENDPOINT = {
   list: (year: number, month: number, sortOrder: SortOrder) => {
     const startDate = `${year}-${month.toString().padStart(2, '0')}-01`
     const endDate = `${year}-${month.toString().padStart(2, '0')}-${new Date(year, month, 0).getDate()}`
-    return `${PAYMENTS_ENDPOINT.default}?date=gte.${startDate}&date=lte.${endDate}&order=date.${sortOrder}`
+    return `${PAYMENTS_ENDPOINT.default}?select=*,category:categories(*)&date=gte.${startDate}&date=lte.${endDate}&order=date.${sortOrder}`
   },
   detail: (paymentId: string) => {
     return `${PAYMENTS_ENDPOINT.default}?id=eq.${paymentId}&select=*,category:categories(*)&limit=1`

--- a/src/router/route.model.ts
+++ b/src/router/route.model.ts
@@ -6,4 +6,5 @@ export const ROUTE = {
     create: '/payments/create',
     update: (id: string) => `/payments/update/${id}`,
   },
+  statistics: '/statistics',
 }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -6,6 +6,7 @@ import { PaymentList } from '~/pages/payment-list'
 import { PaymentCreate } from '~/pages/payment-create'
 import { PaymentDetail } from '~/pages/payment-detail'
 import { PaymentUpdate } from '~/pages/payment-update/payment-update'
+import { Statistics } from '~/pages/statistics/statistics'
 
 export const router = createBrowserRouter([
   {
@@ -27,5 +28,9 @@ export const router = createBrowserRouter([
   {
     path: ROUTE.payment.update(':id'),
     element: <PaymentUpdate />,
+  },
+  {
+    path: ROUTE.statistics,
+    element: <Statistics />,
   },
 ])


### PR DESCRIPTION
## 연관 이슈
#5 
## 내용
- 도넛 차트 구현
- 카테고리별 사용 금액 총합 차트로 표시
- 카테고리별 상세 내역 리스트 추가
## 화면
<img width="837" alt="image" src="https://github.com/user-attachments/assets/26db871a-dc88-48d0-8625-f55483f55dc1" />
