### PR TITLE
전체 리스트 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/themes": "^3.1.6",
     "@tanstack/react-query": "^5.60.5",
     "@tanstack/react-query-devtools": "^5.60.5",
+    "@tanstack/react-table": "^8.21.2",
     "axios": "^1.7.8",
     "es-toolkit": "^1.29.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@tanstack/react-query-devtools':
     specifier: ^5.60.5
     version: 5.60.5(@tanstack/react-query@5.60.5)(react@18.3.1)
+  '@tanstack/react-table':
+    specifier: ^8.21.2
+    version: 8.21.2(react-dom@18.3.1)(react@18.3.1)
   axios:
     specifier: ^1.7.8
     version: 1.7.8
@@ -2021,6 +2024,23 @@ packages:
     dependencies:
       '@tanstack/query-core': 5.60.5
       react: 18.3.1
+    dev: false
+
+  /@tanstack/react-table@8.21.2(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@tanstack/table-core': 8.21.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@tanstack/table-core@8.21.2:
+    resolution: {integrity: sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==}
+    engines: {node: '>=12'}
     dev: false
 
   /@tinyhttp/accepts@2.2.3:

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,0 +1,1 @@
+export * from './label'

--- a/src/components/base/label.tsx
+++ b/src/components/base/label.tsx
@@ -1,0 +1,9 @@
+import { Text } from '@radix-ui/themes'
+
+export const Label = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Text as="label" size="2" weight="bold">
+      {children}
+    </Text>
+  )
+}

--- a/src/components/table/context/index.ts
+++ b/src/components/table/context/index.ts
@@ -1,0 +1,1 @@
+export * from './use-table-context'

--- a/src/components/table/context/use-table-context.ts
+++ b/src/components/table/context/use-table-context.ts
@@ -3,8 +3,16 @@ import { createContext } from 'react'
 
 import { useContext } from 'react'
 
+type TableContextValue<T> = {
+  table: Table<T>
+  pagination: {
+    pageIndex: number
+    pageSize: number
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const TableContext = createContext<Table<any> | null>(null)
+const TableContext = createContext<TableContextValue<any> | null>(null)
 
 // 커스텀 훅으로 테이블 컨텍스트 사용
 const useTableContext = () => {

--- a/src/components/table/context/use-table-context.ts
+++ b/src/components/table/context/use-table-context.ts
@@ -1,0 +1,18 @@
+import { Table } from '@tanstack/react-table'
+import { createContext } from 'react'
+
+import { useContext } from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TableContext = createContext<Table<any> | null>(null)
+
+// 커스텀 훅으로 테이블 컨텍스트 사용
+const useTableContext = () => {
+  const context = useContext(TableContext)
+  if (!context) {
+    throw new Error('Table 컴포넌트 내부에서만 사용할 수 있습니다')
+  }
+  return context
+}
+
+export { TableContext, useTableContext }

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,0 +1,1 @@
+export * from './table'

--- a/src/components/table/style/index.ts
+++ b/src/components/table/style/index.ts
@@ -1,0 +1,8 @@
+import { TableBody, TableFooter, TableRow, TableWrapper } from './table-style'
+
+export const S = {
+  TableWrapper,
+  TableBody,
+  TableRow,
+  TableFooter,
+}

--- a/src/components/table/style/table-style.ts
+++ b/src/components/table/style/table-style.ts
@@ -1,0 +1,29 @@
+import { styled } from 'styled-components'
+import { Table as RadixTable } from '@radix-ui/themes'
+
+export const TableWrapper = styled.div`
+  width: 100%;
+  height: auto;
+`
+
+export const TableBody = styled(RadixTable.Body)`
+  display: block;
+  max-height: 400px;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`
+
+export const TableRow = styled(RadixTable.Row)`
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+`
+
+export const TableFooter = styled.div`
+  width: 100%;
+  border-top: 1px solid var(--gray-5);
+`

--- a/src/components/table/table-body.tsx
+++ b/src/components/table/table-body.tsx
@@ -1,0 +1,26 @@
+import { useTableContext } from './context'
+import { flexRender } from '@tanstack/react-table'
+import { S } from './style'
+import { Table as RadixTable } from '@radix-ui/themes'
+export const TableBody = () => {
+  const table = useTableContext()
+
+  return (
+    <S.TableBody>
+      {table.getRowModel().rows.map((row) => (
+        <S.TableRow key={row.id}>
+          {row.getVisibleCells().map((cell) => (
+            <RadixTable.Cell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</RadixTable.Cell>
+          ))}
+        </S.TableRow>
+      ))}
+      {table.getRowModel().rows.length === 0 && (
+        <S.TableRow>
+          <RadixTable.Cell colSpan={table.getAllColumns().length} style={{ textAlign: 'center' }}>
+            데이터가 없습니다
+          </RadixTable.Cell>
+        </S.TableRow>
+      )}
+    </S.TableBody>
+  )
+}

--- a/src/components/table/table-body.tsx
+++ b/src/components/table/table-body.tsx
@@ -3,8 +3,7 @@ import { flexRender } from '@tanstack/react-table'
 import { S } from './style'
 import { Table as RadixTable } from '@radix-ui/themes'
 export const TableBody = () => {
-  const table = useTableContext()
-
+  const { table } = useTableContext()
   return (
     <S.TableBody>
       {table.getRowModel().rows.map((row) => (

--- a/src/components/table/table-footer.tsx
+++ b/src/components/table/table-footer.tsx
@@ -4,7 +4,9 @@ import { useTableContext } from './context'
 import { S } from './style'
 
 export const TableFooter = () => {
-  const table = useTableContext()
+  const { table, pagination } = useTableContext()
+
+  const isPaginationEnabled = pagination.pageSize !== table.getRowCount()
 
   return (
     <S.TableFooter>
@@ -14,32 +16,34 @@ export const TableFooter = () => {
             {table.getFilteredSelectedRowModel().rows.length}개 선택 / 총 {table.getFilteredRowModel().rows.length}개
           </Text>
         </div>
-        <Flex gap="2" align="center">
-          <Button onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
-            이전
-          </Button>
-          <Text size="2">
-            {table.getState().pagination.pageIndex + 1} / {table.getPageCount()} 페이지
-          </Text>
-          <Button onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
-            다음
-          </Button>
-          <Select.Root
-            defaultValue={String(table.getState().pagination.pageSize)}
-            onValueChange={(value) => {
-              table.setPageSize(Number(value))
-            }}
-          >
-            <Select.Trigger />
-            <Select.Content>
-              {[10, 20, 30, 50].map((pageSize) => (
-                <Select.Item key={pageSize} value={String(pageSize)}>
-                  {pageSize}행
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select.Root>
-        </Flex>
+        {isPaginationEnabled && (
+          <Flex gap="2" align="center">
+            <Button onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+              이전
+            </Button>
+            <Text size="2">
+              {table.getState().pagination.pageIndex + 1} / {table.getPageCount()} 페이지
+            </Text>
+            <Button onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+              다음
+            </Button>
+            <Select.Root
+              value={String(table.getState().pagination.pageSize)} // defaultValue 대신 value 사용
+              onValueChange={(value) => {
+                table.setPageSize(Number(value))
+              }}
+            >
+              <Select.Trigger />
+              <Select.Content>
+                {[10, 20, 30, 50].map((pageSize) => (
+                  <Select.Item key={pageSize} value={String(pageSize)}>
+                    {pageSize}행
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Flex>
+        )}
       </Flex>
     </S.TableFooter>
   )

--- a/src/components/table/table-footer.tsx
+++ b/src/components/table/table-footer.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Select, Text } from '@radix-ui/themes'
 import { useTableContext } from './context'
 import { S } from './style'
 
-export const TableFooter = () => {
+export const TableFooter = ({ pageSizeOptionList = [10, 20, 30, 50] }: { pageSizeOptionList?: number[] }) => {
   const { table, pagination } = useTableContext()
 
   const isPaginationEnabled = pagination.pageSize !== table.getRowCount()
@@ -13,7 +13,8 @@ export const TableFooter = () => {
       <Flex gap="3" align="center" justify="between" p="3">
         <div>
           <Text size="2">
-            {table.getFilteredSelectedRowModel().rows.length}개 선택 / 총 {table.getFilteredRowModel().rows.length}개
+            {/* {table.getFilteredSelectedRowModel().rows.length}개 선택 /  */}총
+            {table.getFilteredRowModel().rows.length}개
           </Text>
         </div>
         {isPaginationEnabled && (
@@ -35,7 +36,7 @@ export const TableFooter = () => {
             >
               <Select.Trigger />
               <Select.Content>
-                {[10, 20, 30, 50].map((pageSize) => (
+                {pageSizeOptionList.map((pageSize) => (
                   <Select.Item key={pageSize} value={String(pageSize)}>
                     {pageSize}행
                   </Select.Item>

--- a/src/components/table/table-footer.tsx
+++ b/src/components/table/table-footer.tsx
@@ -1,0 +1,46 @@
+import { Button, Flex, Select, Text } from '@radix-ui/themes'
+
+import { useTableContext } from './context'
+import { S } from './style'
+
+export const TableFooter = () => {
+  const table = useTableContext()
+
+  return (
+    <S.TableFooter>
+      <Flex gap="3" align="center" justify="between" p="3">
+        <div>
+          <Text size="2">
+            {table.getFilteredSelectedRowModel().rows.length}개 선택 / 총 {table.getFilteredRowModel().rows.length}개
+          </Text>
+        </div>
+        <Flex gap="2" align="center">
+          <Button onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+            이전
+          </Button>
+          <Text size="2">
+            {table.getState().pagination.pageIndex + 1} / {table.getPageCount()} 페이지
+          </Text>
+          <Button onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            다음
+          </Button>
+          <Select.Root
+            defaultValue={String(table.getState().pagination.pageSize)}
+            onValueChange={(value) => {
+              table.setPageSize(Number(value))
+            }}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {[10, 20, 30, 50].map((pageSize) => (
+                <Select.Item key={pageSize} value={String(pageSize)}>
+                  {pageSize}행
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+    </S.TableFooter>
+  )
+}

--- a/src/components/table/table-header.tsx
+++ b/src/components/table/table-header.tsx
@@ -1,0 +1,35 @@
+import { flexRender } from '@tanstack/react-table'
+import { useTableContext } from './context'
+import { Table as RadixTable } from '@radix-ui/themes'
+import { S } from './style'
+
+export const TableHeader = () => {
+  const table = useTableContext()
+
+  return (
+    <RadixTable.Header>
+      {table.getHeaderGroups().map((headerGroup) => (
+        <S.TableRow key={headerGroup.id}>
+          {headerGroup.headers.map((header) => (
+            <RadixTable.ColumnHeaderCell key={header.id}>
+              {header.isPlaceholder ? null : (
+                <div
+                  {...{
+                    className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                    onClick: header.column.getToggleSortingHandler(),
+                  }}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {{
+                    asc: ' 🔼',
+                    desc: ' 🔽',
+                  }[header.column.getIsSorted() as string] ?? null}
+                </div>
+              )}
+            </RadixTable.ColumnHeaderCell>
+          ))}
+        </S.TableRow>
+      ))}
+    </RadixTable.Header>
+  )
+}

--- a/src/components/table/table-header.tsx
+++ b/src/components/table/table-header.tsx
@@ -4,7 +4,7 @@ import { Table as RadixTable } from '@radix-ui/themes'
 import { S } from './style'
 
 export const TableHeader = () => {
-  const table = useTableContext()
+  const { table } = useTableContext()
 
   return (
     <RadixTable.Header>

--- a/src/components/table/table-root.tsx
+++ b/src/components/table/table-root.tsx
@@ -10,7 +10,6 @@ import {
   ColumnDef,
   SortingState,
   RowSelectionState,
-  VisibilityState,
   PaginationState,
 } from '@tanstack/react-table'
 import { TableContext } from './context'
@@ -38,11 +37,14 @@ export const TableRoot = <T,>({
 }: PropsWithChildren<TableRootProps<T>>) => {
   const [sorting, setSorting] = useState<SortingState>([])
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
-  })
+  const [pagination, setPagination] = useState<PaginationState>(
+    enablePagination
+      ? {
+          pageIndex: 0,
+          pageSize: 10,
+        }
+      : { pageIndex: 0, pageSize: data.length }
+  )
 
   const table = useReactTable<T>({
     data,
@@ -50,19 +52,17 @@ export const TableRoot = <T,>({
     state: {
       sorting,
       rowSelection,
-      columnVisibility,
-      pagination: enablePagination ? pagination : undefined,
+      pagination,
     },
     enableRowSelection,
     enableMultiRowSelection,
     enableSorting,
     onSortingChange: setSorting,
     onRowSelectionChange: setRowSelection,
-    onColumnVisibilityChange: setColumnVisibility,
     onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
     meta: {
       updateData,
@@ -70,7 +70,7 @@ export const TableRoot = <T,>({
   })
 
   return (
-    <TableContext.Provider value={table}>
+    <TableContext.Provider value={{ table, pagination }}>
       <S.TableWrapper>
         <RadixTable.Root variant="surface">{children}</RadixTable.Root>
       </S.TableWrapper>

--- a/src/components/table/table-root.tsx
+++ b/src/components/table/table-root.tsx
@@ -17,7 +17,7 @@ import { S } from './style'
 
 interface TableRootProps<T> {
   data: T[]
-  columns: ColumnDef<T, unknown>[]
+  columns: ColumnDef<T>[]
   enableRowSelection?: boolean
   enableMultiRowSelection?: boolean
   enableSorting?: boolean

--- a/src/components/table/table-root.tsx
+++ b/src/components/table/table-root.tsx
@@ -1,0 +1,79 @@
+// ... existing code ...
+import { PropsWithChildren, useState } from 'react'
+import { Table as RadixTable } from '@radix-ui/themes'
+import {
+  getSortedRowModel,
+  useReactTable,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getCoreRowModel,
+  ColumnDef,
+  SortingState,
+  RowSelectionState,
+  VisibilityState,
+  PaginationState,
+} from '@tanstack/react-table'
+import { TableContext } from './context'
+import { S } from './style'
+
+interface TableRootProps<T> {
+  data: T[]
+  columns: ColumnDef<T, unknown>[]
+  enableRowSelection?: boolean
+  enableMultiRowSelection?: boolean
+  enableSorting?: boolean
+  enablePagination?: boolean
+  updateData?: (rowIndex: number, columnId: string, value: unknown) => void
+}
+
+export const TableRoot = <T,>({
+  data,
+  columns,
+  enableRowSelection = false,
+  enableMultiRowSelection = false,
+  enableSorting = false,
+  enablePagination = false,
+  updateData,
+  children,
+}: PropsWithChildren<TableRootProps<T>>) => {
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const table = useReactTable<T>({
+    data,
+    columns,
+    state: {
+      sorting,
+      rowSelection,
+      columnVisibility,
+      pagination: enablePagination ? pagination : undefined,
+    },
+    enableRowSelection,
+    enableMultiRowSelection,
+    enableSorting,
+    onSortingChange: setSorting,
+    onRowSelectionChange: setRowSelection,
+    onColumnVisibilityChange: setColumnVisibility,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
+    getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    meta: {
+      updateData,
+    },
+  })
+
+  return (
+    <TableContext.Provider value={table}>
+      <S.TableWrapper>
+        <RadixTable.Root variant="surface">{children}</RadixTable.Root>
+      </S.TableWrapper>
+    </TableContext.Provider>
+  )
+}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,0 +1,11 @@
+import { TableBody } from './table-body'
+import { TableFooter } from './table-footer'
+import { TableHeader } from './table-header'
+import { TableRoot } from './table-root'
+
+export const Table = {
+  Root: TableRoot,
+  Header: TableHeader,
+  Body: TableBody,
+  Footer: TableFooter,
+}

--- a/src/constants/payment.ts
+++ b/src/constants/payment.ts
@@ -2,3 +2,5 @@ export const PAYMENT_TYPE = {
   INCOME: 'income',
   EXPENSE: 'expense',
 } as const
+
+export const MAX_MEMO_LENGTH = 60

--- a/src/pages/home/components/index.ts
+++ b/src/pages/home/components/index.ts
@@ -1,0 +1,2 @@
+export * from './payment-create-form'
+export * from './payment-list-table'

--- a/src/pages/home/components/payment-add-form.tsx
+++ b/src/pages/home/components/payment-add-form.tsx
@@ -1,3 +1,0 @@
-export const PaymentAddForm = () => {
-  return <></>
-}

--- a/src/pages/home/components/payment-add-form.tsx
+++ b/src/pages/home/components/payment-add-form.tsx
@@ -1,0 +1,3 @@
+export const PaymentAddForm = () => {
+  return <></>
+}

--- a/src/pages/home/components/payment-create-form.tsx
+++ b/src/pages/home/components/payment-create-form.tsx
@@ -7,7 +7,7 @@ import { MAX_MEMO_LENGTH } from '~/constants/payment'
 import { Label } from '~/components/base'
 
 export const PaymentCreateForm = () => {
-  const { payment, dispatch, categoryList } = usePaymentCreateFormViewModel()
+  const { payment, dispatch, categoryList, onSubmit } = usePaymentCreateFormViewModel()
   const { type, amount, payee, date, memo } = payment
 
   const displayAmount = amount === 0 ? '' : commaNumber(amount)
@@ -31,8 +31,12 @@ export const PaymentCreateForm = () => {
             <SegmentedControl.Item value="income">수입</SegmentedControl.Item>
           </SegmentedControl.Root>
           <Flex gap="2">
-            <Button variant="soft">초기화</Button>
-            <Button variant="solid">저장</Button>
+            <Button variant="soft" onClick={() => dispatch({ type: 'CLEAR' })}>
+              초기화
+            </Button>
+            <Button variant="solid" onClick={onSubmit}>
+              저장
+            </Button>
           </Flex>
         </Flex>
         <Grid columns="5" gap="4">

--- a/src/pages/home/components/payment-create-form.tsx
+++ b/src/pages/home/components/payment-create-form.tsx
@@ -7,7 +7,7 @@ import { MAX_MEMO_LENGTH } from '~/constants/payment'
 import { Label } from '~/components/base'
 
 export const PaymentCreateForm = () => {
-  const { payment, dispatch, categoryList, onSubmit } = usePaymentCreateFormViewModel()
+  const { payment, dispatch, categoryList, handleSubmit, handleKeyDown } = usePaymentCreateFormViewModel()
   const { type, amount, payee, date, memo } = payment
 
   const displayAmount = amount === 0 ? '' : commaNumber(amount)
@@ -19,102 +19,104 @@ export const PaymentCreateForm = () => {
       <Text size="4" weight="bold">
         거래 내역 추가
       </Text>
-      <Card>
-        <Flex justify="between" align="center">
-          <SegmentedControl.Root
-            defaultValue="expense"
-            value={type}
-            onValueChange={(value) => dispatch({ type: 'SET_TYPE', payload: value as 'expense' | 'income' })}
-            size="2"
-          >
-            <SegmentedControl.Item value="expense">지출</SegmentedControl.Item>
-            <SegmentedControl.Item value="income">수입</SegmentedControl.Item>
-          </SegmentedControl.Root>
-          <Flex gap="2">
-            <Button variant="soft" onClick={() => dispatch({ type: 'CLEAR' })}>
-              초기화
-            </Button>
-            <Button variant="solid" onClick={onSubmit}>
-              저장
-            </Button>
-          </Flex>
-        </Flex>
-        <Grid columns="5" gap="4">
-          <Flex direction="column" gap="2">
-            <Label>금액</Label>
-            <TextField.Root
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9, ,]*"
-              placeholder="금액을 입력하세요"
-              value={displayAmount}
-              onChange={({ target: { value } }) => dispatch({ type: 'SET_AMOUNT', payload: parseCommaNumber(value) })}
-              size={ELEMENT_SIZE}
-              required
+      <Card asChild>
+        <form onKeyDown={handleKeyDown}>
+          <Flex justify="between" align="center">
+            <SegmentedControl.Root
+              defaultValue="expense"
+              value={type}
+              onValueChange={(value) => dispatch({ type: 'SET_TYPE', payload: value as 'expense' | 'income' })}
+              size="2"
             >
-              <TextField.Slot side="right">
-                <Text as="label" size={ELEMENT_SIZE} weight="bold">
-                  {WON_UNIT}
-                </Text>
-              </TextField.Slot>
-            </TextField.Root>
+              <SegmentedControl.Item value="expense">지출</SegmentedControl.Item>
+              <SegmentedControl.Item value="income">수입</SegmentedControl.Item>
+            </SegmentedControl.Root>
+            <Flex gap="2">
+              <Button variant="soft" onClick={() => dispatch({ type: 'CLEAR' })}>
+                초기화
+              </Button>
+              <Button variant="solid" onClick={handleSubmit}>
+                저장
+              </Button>
+            </Flex>
           </Flex>
+          <Grid columns="5" gap="4">
+            <Flex direction="column" gap="2">
+              <Label>금액</Label>
+              <TextField.Root
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9, ,]*"
+                placeholder="금액을 입력하세요"
+                value={displayAmount}
+                onChange={({ target: { value } }) => dispatch({ type: 'SET_AMOUNT', payload: parseCommaNumber(value) })}
+                size={ELEMENT_SIZE}
+                required
+              >
+                <TextField.Slot side="right">
+                  <Text as="label" size={ELEMENT_SIZE} weight="bold">
+                    {WON_UNIT}
+                  </Text>
+                </TextField.Slot>
+              </TextField.Root>
+            </Flex>
 
-          <Flex direction="column" gap="2">
-            <Label>지출처</Label>
-            <TextField.Root
-              type="text"
-              placeholder={payeePlaceholder}
-              size={ELEMENT_SIZE}
-              value={payee}
-              onChange={(event) => dispatch({ type: 'SET_PAYEE', payload: event.target.value })}
-              required
-            />
-          </Flex>
+            <Flex direction="column" gap="2">
+              <Label>지출처</Label>
+              <TextField.Root
+                type="text"
+                placeholder={payeePlaceholder}
+                size={ELEMENT_SIZE}
+                value={payee}
+                onChange={(event) => dispatch({ type: 'SET_PAYEE', payload: event.target.value })}
+                required
+              />
+            </Flex>
 
-          <Flex direction="column" gap="2">
-            <Label>날짜</Label>
-            <TextField.Root
-              type="date"
-              placeholder="날짜를 입력하세요"
-              size={ELEMENT_SIZE}
-              value={date}
-              onChange={(event) => dispatch({ type: 'SET_DATE', payload: event.target.value })}
-              required
-            />
-          </Flex>
+            <Flex direction="column" gap="2">
+              <Label>날짜</Label>
+              <TextField.Root
+                type="date"
+                placeholder="날짜를 입력하세요"
+                size={ELEMENT_SIZE}
+                value={date}
+                onChange={(event) => dispatch({ type: 'SET_DATE', payload: event.target.value })}
+                required
+              />
+            </Flex>
 
-          <Flex direction="column" gap="2">
-            <Label>카테고리</Label>
-            <Select.Root
-              size={ELEMENT_SIZE}
-              defaultValue={categoryList?.[0].id.toString()}
-              onValueChange={(value) => dispatch({ type: 'SET_CATEGORY', payload: Number(value) })}
-            >
-              <Select.Trigger />
-              <Select.Content>
-                {categoryList?.map((category) => (
-                  <Select.Item key={category.id} value={category.id.toString()}>
-                    {category.name}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select.Root>
-          </Flex>
+            <Flex direction="column" gap="2">
+              <Label>카테고리</Label>
+              <Select.Root
+                size={ELEMENT_SIZE}
+                defaultValue={categoryList?.[0].id.toString()}
+                onValueChange={(value) => dispatch({ type: 'SET_CATEGORY', payload: Number(value) })}
+              >
+                <Select.Trigger />
+                <Select.Content>
+                  {categoryList?.map((category) => (
+                    <Select.Item key={category.id} value={category.id.toString()}>
+                      {category.name}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select.Root>
+            </Flex>
 
-          <Flex direction="column" gap="2">
-            <Label>메모</Label>
-            <TextArea
-              size={ELEMENT_SIZE}
-              placeholder="메모를 남겨보세요"
-              onChange={({ target: { value } }) => dispatch({ type: 'SET_MEMO', payload: value })}
-              maxLength={MAX_MEMO_LENGTH}
-            />
-            <Text size="1" align="right">
-              나만 볼 수 있는 메모 {memo.length}/{MAX_MEMO_LENGTH}
-            </Text>
-          </Flex>
-        </Grid>
+            <Flex direction="column" gap="2">
+              <Label>메모</Label>
+              <TextArea
+                size={ELEMENT_SIZE}
+                placeholder="메모를 남겨보세요"
+                onChange={({ target: { value } }) => dispatch({ type: 'SET_MEMO', payload: value })}
+                maxLength={MAX_MEMO_LENGTH}
+              />
+              <Text size="1" align="right">
+                나만 볼 수 있는 메모 {memo.length}/{MAX_MEMO_LENGTH}
+              </Text>
+            </Flex>
+          </Grid>
+        </form>
       </Card>
     </Flex>
   )

--- a/src/pages/home/components/payment-create-form.tsx
+++ b/src/pages/home/components/payment-create-form.tsx
@@ -108,6 +108,7 @@ export const PaymentCreateForm = () => {
               <TextArea
                 size={ELEMENT_SIZE}
                 placeholder="메모를 남겨보세요"
+                value={memo}
                 onChange={({ target: { value } }) => dispatch({ type: 'SET_MEMO', payload: value })}
                 maxLength={MAX_MEMO_LENGTH}
               />

--- a/src/pages/home/components/payment-create-form.tsx
+++ b/src/pages/home/components/payment-create-form.tsx
@@ -1,0 +1,117 @@
+import { Button, Flex, SegmentedControl, Select, Text, TextArea, TextField, Grid, Card } from '@radix-ui/themes'
+import { ELEMENT_SIZE } from '~/constants/style'
+import { WON_UNIT } from '~/constants/unit'
+import { commaNumber, parseCommaNumber } from '~/utils/number-format'
+import { usePaymentCreateFormViewModel } from '../hooks/use-payment-create-form-view-model'
+import { MAX_MEMO_LENGTH } from '~/constants/payment'
+import { Label } from '~/components/base'
+
+export const PaymentCreateForm = () => {
+  const { payment, dispatch, categoryList } = usePaymentCreateFormViewModel()
+  const { type, amount, payee, date, memo } = payment
+
+  const displayAmount = amount === 0 ? '' : commaNumber(amount)
+
+  const payeePlaceholder = `${type === 'expense' ? '지출처' : '수입처'}를 입력하세요`
+
+  return (
+    <Flex direction="column" gap="2">
+      <Text size="4" weight="bold">
+        거래 내역 추가
+      </Text>
+      <Card>
+        <Flex justify="between" align="center">
+          <SegmentedControl.Root
+            defaultValue="expense"
+            value={type}
+            onValueChange={(value) => dispatch({ type: 'SET_TYPE', payload: value as 'expense' | 'income' })}
+            size="2"
+          >
+            <SegmentedControl.Item value="expense">지출</SegmentedControl.Item>
+            <SegmentedControl.Item value="income">수입</SegmentedControl.Item>
+          </SegmentedControl.Root>
+          <Flex gap="2">
+            <Button variant="soft">초기화</Button>
+            <Button variant="solid">저장</Button>
+          </Flex>
+        </Flex>
+        <Grid columns="5" gap="4">
+          <Flex direction="column" gap="2">
+            <Label>금액</Label>
+            <TextField.Root
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9, ,]*"
+              placeholder="금액을 입력하세요"
+              value={displayAmount}
+              onChange={({ target: { value } }) => dispatch({ type: 'SET_AMOUNT', payload: parseCommaNumber(value) })}
+              size={ELEMENT_SIZE}
+              required
+            >
+              <TextField.Slot side="right">
+                <Text as="label" size={ELEMENT_SIZE} weight="bold">
+                  {WON_UNIT}
+                </Text>
+              </TextField.Slot>
+            </TextField.Root>
+          </Flex>
+
+          <Flex direction="column" gap="2">
+            <Label>지출처</Label>
+            <TextField.Root
+              type="text"
+              placeholder={payeePlaceholder}
+              size={ELEMENT_SIZE}
+              value={payee}
+              onChange={(event) => dispatch({ type: 'SET_PAYEE', payload: event.target.value })}
+              required
+            />
+          </Flex>
+
+          <Flex direction="column" gap="2">
+            <Label>날짜</Label>
+            <TextField.Root
+              type="date"
+              placeholder="날짜를 입력하세요"
+              size={ELEMENT_SIZE}
+              value={date}
+              onChange={(event) => dispatch({ type: 'SET_DATE', payload: event.target.value })}
+              required
+            />
+          </Flex>
+
+          <Flex direction="column" gap="2">
+            <Label>카테고리</Label>
+            <Select.Root
+              size={ELEMENT_SIZE}
+              defaultValue={categoryList?.[0].id.toString()}
+              onValueChange={(value) => dispatch({ type: 'SET_CATEGORY', payload: Number(value) })}
+            >
+              <Select.Trigger />
+              <Select.Content>
+                {categoryList?.map((category) => (
+                  <Select.Item key={category.id} value={category.id.toString()}>
+                    {category.name}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Flex>
+
+          <Flex direction="column" gap="2">
+            <Label>메모</Label>
+            <TextArea
+              size={ELEMENT_SIZE}
+              placeholder="메모를 남겨보세요"
+              onChange={({ target: { value } }) => dispatch({ type: 'SET_MEMO', payload: value })}
+              maxLength={MAX_MEMO_LENGTH}
+            />
+            <Text size="1" align="right">
+              나만 볼 수 있는 메모 {memo.length}/{MAX_MEMO_LENGTH}
+            </Text>
+          </Flex>
+        </Grid>
+      </Card>
+    </Flex>
+  )
+}

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -1,0 +1,25 @@
+import { Table } from '@radix-ui/themes'
+import { useAllPaymentsListQuery } from '~/queries/payment'
+
+export const PaymentListTable = () => {
+  const { data } = useAllPaymentsListQuery()
+
+  return (
+    <>
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>금액</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>거래처</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>카테고리</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>거래일시</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>메모</Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row></Table.Row>
+        </Table.Body>
+      </Table.Root>
+    </>
+  )
+}

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -10,8 +10,8 @@ export const PaymentListTable = () => {
   const { data } = useAllPaymentsListQuery()
 
   return (
-    <Flex direction="column" gap="4">
-      <Text size="5" weight="bold">
+    <Flex direction="column" gap="2">
+      <Text size="4" weight="bold">
         입출금 내역
       </Text>
       <Table.Root<Payment> data={data} columns={columns}>

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -1,5 +1,7 @@
-import { Table, Text } from '@radix-ui/themes'
-import styled from 'styled-components'
+import { Checkbox, Text } from '@radix-ui/themes'
+
+import { Table } from '~/components/table'
+
 import { useAllPaymentsListQuery } from '~/queries/payment'
 import { paymentAmountFormat } from '~/utils/units'
 
@@ -17,54 +19,45 @@ export const PaymentListTable = () => {
   }))
 
   return (
-    <TableWrapper>
-      <Table.Root variant="surface">
-        <Table.Header>
-          <TableRow>
-            <Table.ColumnHeaderCell>금액</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>거래처</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>카테고리</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>거래일시</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>메모</Table.ColumnHeaderCell>
-          </TableRow>
-        </Table.Header>
-        <TableBody>
-          {paymentList?.map(({ id, type, amount, from, to, category, date, memo }) => (
-            <TableRow key={id}>
-              <Table.Cell>
-                <Text weight="medium" color={type === 'expense' ? undefined : 'blue'}>
-                  {paymentAmountFormat(amount, type, 'short')}
-                </Text>
-              </Table.Cell>
-              <Table.Cell>{type === 'expense' ? to : from}</Table.Cell>
-              <Table.Cell>{category}</Table.Cell>
-              <Table.Cell>{date}</Table.Cell>
-              <Table.Cell>{memo}</Table.Cell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table.Root>
-    </TableWrapper>
+    <Table.Root
+      data={paymentList}
+      columns={columns}
+      // enableMultiRowSelection={true}
+      enableSorting={true}
+      enablePagination={true}
+    >
+      <Table.Header />
+      <Table.Body />
+      <Table.Footer />
+    </Table.Root>
   )
 }
 
-const TableWrapper = styled.div`
-  width: 100%;
-  height: 500px;
-`
-
-const TableBody = styled(Table.Body)`
-  display: block;
-  max-height: 400px;
-  overflow-y: scroll;
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`
-const TableRow = styled(Table.Row)`
-  display: table;
-  width: 100%;
-  table-layout: fixed;
-`
+const columns = [
+  {
+    accessorKey: 'amount',
+    header: '금액',
+    cell: ({ row }) => (
+      <Text weight="medium" color={row.original.type === 'expense' ? undefined : 'blue'}>
+        {paymentAmountFormat(row.original.amount, row.original.type, 'short')}
+      </Text>
+    ),
+  },
+  {
+    accessorKey: 'counterpart',
+    header: '거래처',
+    cell: ({ row }) => (row.original.type === 'expense' ? row.original.to : row.original.from),
+  },
+  {
+    accessorKey: 'category',
+    header: '카테고리',
+  },
+  {
+    accessorKey: 'date',
+    header: '거래일시',
+  },
+  {
+    accessorKey: 'memo',
+    header: '메모',
+  },
+]

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -19,13 +19,7 @@ export const PaymentListTable = () => {
   }))
 
   return (
-    <Table.Root
-      data={paymentList}
-      columns={columns}
-      // enableMultiRowSelection={true}
-      enableSorting={true}
-      enablePagination={true}
-    >
+    <Table.Root data={paymentList} columns={columns} enablePagination>
       <Table.Header />
       <Table.Body />
       <Table.Footer />

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@radix-ui/themes'
+import { Flex, Text } from '@radix-ui/themes'
 import { ColumnDef } from '@tanstack/react-table'
 
 import { Table } from '~/components/table'
@@ -10,11 +10,15 @@ export const PaymentListTable = () => {
   const { data } = useAllPaymentsListQuery()
 
   return (
-    <Table.Root<Payment> data={data} columns={columns} enablePagination>
-      <Table.Header />
-      <Table.Body />
-      <Table.Footer />
-    </Table.Root>
+    <Flex direction="column" gap="4">
+      <Text size="5" weight="bold">
+        입출금 내역
+      </Text>
+      <Table.Root<Payment> data={data} columns={columns}>
+        <Table.Header />
+        <Table.Body />
+      </Table.Root>
+    </Flex>
   )
 }
 
@@ -40,7 +44,12 @@ const columns: ColumnDef<Payment>[] = [
   },
   {
     accessorKey: 'date',
-    header: '거래일시',
+    header: '거래일자',
+    cell: ({ row }) => (
+      <Text size="2" weight="medium">
+        {row.original.date.split('T')[0]}
+      </Text>
+    ),
   },
   {
     accessorKey: 'memo',

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -1,25 +1,70 @@
-import { Table } from '@radix-ui/themes'
+import { Table, Text } from '@radix-ui/themes'
+import styled from 'styled-components'
 import { useAllPaymentsListQuery } from '~/queries/payment'
+import { paymentAmountFormat } from '~/utils/units'
 
 export const PaymentListTable = () => {
   const { data } = useAllPaymentsListQuery()
+  const paymentList = data?.map((payment) => ({
+    id: payment.id,
+    type: payment.type,
+    amount: payment.amount,
+    from: payment.from,
+    to: payment.to,
+    category: payment.category.name,
+    date: payment.date.replace('T', ' '),
+    memo: payment.memo,
+  }))
 
   return (
-    <>
-      <Table.Root>
+    <TableWrapper>
+      <Table.Root variant="surface">
         <Table.Header>
-          <Table.Row>
+          <TableRow>
             <Table.ColumnHeaderCell>금액</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>거래처</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>카테고리</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>거래일시</Table.ColumnHeaderCell>
             <Table.ColumnHeaderCell>메모</Table.ColumnHeaderCell>
-          </Table.Row>
+          </TableRow>
         </Table.Header>
-        <Table.Body>
-          <Table.Row></Table.Row>
-        </Table.Body>
+        <TableBody>
+          {paymentList?.map(({ id, type, amount, from, to, category, date, memo }) => (
+            <TableRow key={id}>
+              <Table.Cell>
+                <Text weight="medium" color={type === 'expense' ? undefined : 'blue'}>
+                  {paymentAmountFormat(amount, type, 'short')}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>{type === 'expense' ? to : from}</Table.Cell>
+              <Table.Cell>{category}</Table.Cell>
+              <Table.Cell>{date}</Table.Cell>
+              <Table.Cell>{memo}</Table.Cell>
+            </TableRow>
+          ))}
+        </TableBody>
       </Table.Root>
-    </>
+    </TableWrapper>
   )
 }
+
+const TableWrapper = styled.div`
+  width: 100%;
+  height: 500px;
+`
+
+const TableBody = styled(Table.Body)`
+  display: block;
+  max-height: 400px;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`
+const TableRow = styled(Table.Row)`
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+`

--- a/src/pages/home/components/payment-list-table.tsx
+++ b/src/pages/home/components/payment-list-table.tsx
@@ -1,25 +1,16 @@
-import { Checkbox, Text } from '@radix-ui/themes'
+import { Text } from '@radix-ui/themes'
+import { ColumnDef } from '@tanstack/react-table'
 
 import { Table } from '~/components/table'
 
-import { useAllPaymentsListQuery } from '~/queries/payment'
+import { Payment, useAllPaymentsListQuery } from '~/queries/payment'
 import { paymentAmountFormat } from '~/utils/units'
 
 export const PaymentListTable = () => {
   const { data } = useAllPaymentsListQuery()
-  const paymentList = data?.map((payment) => ({
-    id: payment.id,
-    type: payment.type,
-    amount: payment.amount,
-    from: payment.from,
-    to: payment.to,
-    category: payment.category.name,
-    date: payment.date.replace('T', ' '),
-    memo: payment.memo,
-  }))
 
   return (
-    <Table.Root data={paymentList} columns={columns} enablePagination>
+    <Table.Root<Payment> data={data} columns={columns} enablePagination>
       <Table.Header />
       <Table.Body />
       <Table.Footer />
@@ -27,7 +18,7 @@ export const PaymentListTable = () => {
   )
 }
 
-const columns = [
+const columns: ColumnDef<Payment>[] = [
   {
     accessorKey: 'amount',
     header: '금액',
@@ -44,6 +35,7 @@ const columns = [
   },
   {
     accessorKey: 'category',
+    accessorFn: (row) => row.category.name,
     header: '카테고리',
   },
   {

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,11 +1,11 @@
-import { PaymentAddForm } from './components/payment-add-form'
-import { PaymentListTable } from './components/payment-list-table'
+import { Flex } from '@radix-ui/themes'
+import { PaymentCreateForm, PaymentListTable } from './components'
 
 export const Home = () => {
   return (
-    <>
-      <PaymentAddForm />
+    <Flex height="100%" direction="column" gap="5">
       <PaymentListTable />
-    </>
+      <PaymentCreateForm />
+    </Flex>
   )
 }

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,0 +1,11 @@
+import { PaymentAddForm } from './components/payment-add-form'
+import { PaymentListTable } from './components/payment-list-table'
+
+export const Home = () => {
+  return (
+    <>
+      <PaymentAddForm />
+      <PaymentListTable />
+    </>
+  )
+}

--- a/src/pages/home/hooks/use-payment-create-form-view-model.tsx
+++ b/src/pages/home/hooks/use-payment-create-form-view-model.tsx
@@ -16,7 +16,7 @@ export const usePaymentCreateFormViewModel = () => {
 
   const { mutateAsync: createPayment } = usePaymentCreateMutation()
 
-  const onSubmit = async () => {
+  const handleSubmit = async () => {
     const { payee, ...rest } = payment
     const payload = {
       ...rest,
@@ -27,7 +27,14 @@ export const usePaymentCreateFormViewModel = () => {
     await refetchPayments()
   }
 
-  return { payment, dispatch, categoryList, onSubmit }
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return { payment, dispatch, categoryList, handleSubmit, handleKeyDown }
 }
 
 const initialState: Payment = {

--- a/src/pages/home/hooks/use-payment-create-form-view-model.tsx
+++ b/src/pages/home/hooks/use-payment-create-form-view-model.tsx
@@ -1,0 +1,67 @@
+import { useReducer } from 'react'
+import { z } from 'zod'
+import { MAX_MEMO_LENGTH, PAYMENT_TYPE } from '~/constants/payment'
+import { SORT_ORDER } from '~/constants/query'
+import { useCategoryListQuery } from '~/queries/category'
+import { paymentCreateSchema } from '~/queries/payment/payment.type'
+
+type Payment = z.infer<typeof paymentCreateSchema>
+
+export const usePaymentCreateFormViewModel = () => {
+  const [payment, dispatch] = useReducer(reducer, initialState)
+
+  const { data: categoryList } = useCategoryListQuery(SORT_ORDER.ASC)
+
+  return { payment, dispatch, categoryList }
+}
+
+const initialState: Payment = {
+  type: PAYMENT_TYPE.EXPENSE,
+  amount: 0,
+  payee: '',
+  date: '',
+  category: 0,
+  memo: '',
+}
+
+function reducer(state: Payment, action: ActionType) {
+  switch (action.type) {
+    case 'SET_TYPE':
+      return { ...state, type: action.payload }
+    case 'SET_AMOUNT':
+      return { ...state, amount: action.payload }
+    case 'SET_PAYEE':
+      return { ...state, payee: action.payload }
+    case 'SET_DATE':
+      return { ...state, date: action.payload }
+    case 'SET_CATEGORY':
+      return { ...state, category: action.payload }
+    case 'SET_MEMO':
+      if (action.payload.length > MAX_MEMO_LENGTH) {
+        const memo = action.payload.slice(0, MAX_MEMO_LENGTH)
+        return { ...state, memo }
+      }
+      return { ...state, memo: action.payload }
+    case 'CLEAR':
+      return initialState
+  }
+}
+
+type ActionType =
+  | { type: 'SET_TYPE'; payload: Payment['type'] }
+  | { type: 'SET_AMOUNT'; payload: Payment['amount'] }
+  | { type: 'SET_PAYEE'; payload: Payment['payee'] }
+  | { type: 'SET_DATE'; payload: Payment['date'] }
+  | { type: 'SET_CATEGORY'; payload: Payment['category'] }
+  | { type: 'SET_MEMO'; payload: Payment['memo'] }
+  | { type: 'CLEAR' }
+
+export const ACTION_TYPE = {
+  SET_TYPE: 'SET_TYPE',
+  SET_AMOUNT: 'SET_AMOUNT',
+  SET_PAYEE: 'SET_PAYEE',
+  SET_DATE: 'SET_DATE',
+  SET_CATEGORY: 'SET_CATEGORY',
+  SET_MEMO: 'SET_MEMO',
+  CLEAR: 'CLEAR',
+} as const

--- a/src/pages/home/index.ts
+++ b/src/pages/home/index.ts
@@ -1,0 +1,1 @@
+export * from './home'

--- a/src/pages/payment-list/hooks/use-payment-list-view-model.ts
+++ b/src/pages/payment-list/hooks/use-payment-list-view-model.ts
@@ -28,7 +28,6 @@ export const usePaymentListViewModel = () => {
     [data]
   )
 
-  // Map을 배열로 변환합니다.
   const dailyPaymentArray = dailyPaymentMap
     ? Array.from(dailyPaymentMap.entries()).map(([date, payments]) => [dateFormat(date), payments])
     : []

--- a/src/pages/payment-update/index.ts
+++ b/src/pages/payment-update/index.ts
@@ -1,0 +1,1 @@
+export * from './payment-update'

--- a/src/pages/statistics/index.ts
+++ b/src/pages/statistics/index.ts
@@ -1,0 +1,1 @@
+export * from './statistics'

--- a/src/queries/payment/payment.api.ts
+++ b/src/queries/payment/payment.api.ts
@@ -18,7 +18,7 @@ export const useAllPaymentsListQuery = () =>
   // TODO: usePaymentsListQuery 리팩토링 후 삭제
   useSuspenseQuery<Payment[]>({
     queryKey: PAYMENTS_KEY.default,
-    queryFn: () => request(PAYMENTS_ENDPOINT.all({ sortOrder: 'asc' })),
+    queryFn: () => request(PAYMENTS_ENDPOINT.all({ sortOrder: 'desc' })),
   })
 
 export const usePaymentDetailQuery = (paymentId: string) =>

--- a/src/queries/payment/payment.api.ts
+++ b/src/queries/payment/payment.api.ts
@@ -5,10 +5,20 @@ import { Payment, PaymentMutationPayload } from './payment.type'
 import { request } from '~/utils/request'
 import { SortOrder } from '~/types/query.type'
 
-export const usePaymentsListQuery = (year: number, month: number, sortOrder: SortOrder) =>
+export const usePaymentsListQuery = (
+  year: number,
+  month: number,
+  sortOrder: SortOrder // TODO: 추후 searchOption 객체로 파라미터 변경 => 빈 객체면 전체 조회
+) =>
   useSuspenseQuery<Payment[]>({
     queryKey: PAYMENTS_KEY.list(year, month, sortOrder),
     queryFn: () => request(PAYMENTS_ENDPOINT.list(year, month, sortOrder)),
+  })
+export const useAllPaymentsListQuery = () =>
+  // TODO: usePaymentsListQuery 리팩토링 후 삭제
+  useSuspenseQuery<Payment[]>({
+    queryKey: PAYMENTS_KEY.default,
+    queryFn: () => request(PAYMENTS_ENDPOINT.all({ sortOrder: 'asc' })),
   })
 
 export const usePaymentDetailQuery = (paymentId: string) =>

--- a/src/queries/payment/payment.model.ts
+++ b/src/queries/payment/payment.model.ts
@@ -2,6 +2,8 @@ import { SortOrder } from '~/types/query.type'
 
 export const PAYMENTS_ENDPOINT = {
   default: '/payments',
+  all: ({ sortOrder }: { sortOrder?: SortOrder }) =>
+    `${PAYMENTS_ENDPOINT.default}?select=*,category:categories(*)&order=date.${sortOrder}`,
   list: (year: number, month: number, sortOrder: SortOrder) => {
     const startDate = `${year}-${month.toString().padStart(2, '0')}-01`
     const endDate = `${year}-${month.toString().padStart(2, '0')}-${new Date(year, month, 0).getDate()}`

--- a/src/queries/payment/payment.type.ts
+++ b/src/queries/payment/payment.type.ts
@@ -45,3 +45,14 @@ export interface PaymentMutationPayload extends PaymentBaseType {
   from?: string
   to?: string
 }
+
+// FIXME: 스키마 타입 단순화 필요. 위의 타입들 추후 없애기
+// 기본적으로 상태로 다룰 타입을 스키마로 정의하고 실제 요청 타입은 스키마를 확장하여 정의 => 그래야 유효성 검사 쉬워짐
+export const paymentCreateSchema = z.object({
+  type: z.enum([PAYMENT_TYPE.INCOME, PAYMENT_TYPE.EXPENSE]),
+  amount: z.number().positive().max(1000000000, '너무 큰 금액입니다.').min(1, '최소 1원 이상 입력해주세요'),
+  payee: z.string().min(1, '필수 입력 항목입니다.'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}/, '올바른 날짜를 입력해주세요'),
+  category: z.number().min(1),
+  memo: z.string().max(60, '최대 60자까지 입력 가능합니다.'),
+})

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -5,13 +5,14 @@ import { ROUTE } from './route.model'
 import { PaymentList } from '~/pages/payment-list'
 import { PaymentCreate } from '~/pages/payment-create'
 import { PaymentDetail } from '~/pages/payment-detail'
-import { PaymentUpdate } from '~/pages/payment-update/payment-update'
-import { Statistics } from '~/pages/statistics/statistics'
+import { PaymentUpdate } from '~/pages/payment-update'
+import { Statistics } from '~/pages/statistics'
+import { Home } from '~/pages/home'
 
 export const router = createBrowserRouter([
   {
     path: ROUTE.root,
-    element: <div>home</div>,
+    element: <Home />,
   },
   {
     path: ROUTE.payment.list,


### PR DESCRIPTION
## 연관 이슈
#15 
## 내용
- 전체 거래내역을 테이블 형태로 표시 
  - tanstack-table 추가
  - 재사용 가능한 table 컴포넌트 구현
- 페이지 내에서 거래내역 등록 기능 추가
  - cmd(ctrl) + enter로 등록가능
## 화면
<img width="1423" alt="image" src="https://github.com/user-attachments/assets/9c005755-7239-480d-9b0a-eecc992ced7e" />
