### PR TITLE
테이블 내 즉시 수정 셀 추가

### DIFF
--- a/src/components/calender/calender.tsx
+++ b/src/components/calender/calender.tsx
@@ -60,10 +60,10 @@ export function Calender({ year, month, day, dispatch, getDailyTransaction, onDa
               {date}
               <Flex direction="column" align="center" justify="center">
                 <Text size="1" color="blue">
-                  {income > 0 && transactionAmountFormat(income, 'income', 'short')}
+                  {income > 0 && transactionAmountFormat({ amount: income, type: 'income' })}
                 </Text>
                 <Text size="1" color="red">
-                  {expense > 0 && transactionAmountFormat(expense, 'expense', 'short')}
+                  {expense > 0 && transactionAmountFormat({ amount: expense, type: 'expense' })}
                 </Text>
               </Flex>
             </DayButton>

--- a/src/components/table/table-editable-cell.tsx
+++ b/src/components/table/table-editable-cell.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react'
+
+interface TableEditableCellProps {
+  renderEditable: (props: { endEdit: () => void }) => React.ReactNode
+  renderReadOnly: (props: { startEdit: () => void }) => React.ReactNode
+}
+
+export const TableEditableCell = ({ renderEditable, renderReadOnly }: TableEditableCellProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const startEdit = () => {
+    setIsEditing(true)
+  }
+  const endEdit = () => {
+    setIsEditing(false)
+  }
+  return isEditing ? renderEditable({ endEdit }) : renderReadOnly({ startEdit })
+}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,4 +1,5 @@
 import { TableBody } from './table-body'
+import { TableEditableCell } from './table-editable-cell'
 import { TableFooter } from './table-footer'
 import { TableHeader } from './table-header'
 import { TableRoot } from './table-root'
@@ -8,4 +9,5 @@ export const Table = {
   Header: TableHeader,
   Body: TableBody,
   Footer: TableFooter,
+  EditableCell: TableEditableCell,
 }

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -1,1 +1,2 @@
 export const ELEMENT_SIZE = '3'
+export const ELEMENT_SIZE_SMALL = '2'

--- a/src/pages/statistics/statistics.tsx
+++ b/src/pages/statistics/statistics.tsx
@@ -74,7 +74,7 @@ const Legend = ({ label, color, ratio, amount }: { label: string; color: string;
         </Text>
       </Flex>
       <Text weight="medium" ml="auto">
-        {transactionAmountFormat(amount, 'expense', 'full')}
+        {transactionAmountFormat({ amount, type: 'expense', mode: 'full' })}
       </Text>
     </Flex>
   )

--- a/src/pages/transaction-list/components/daily-transaction-list.tsx
+++ b/src/pages/transaction-list/components/daily-transaction-list.tsx
@@ -38,7 +38,7 @@ const TransactionInfo = ({ transaction }: { transaction: Transaction }) => {
       </IconButton>
       <Flex direction="column">
         <Text weight="medium" color={transaction.type === 'expense' ? undefined : 'blue'}>
-          {transactionAmountFormat(transaction.amount, transaction.type, 'full')}
+          {transactionAmountFormat({ amount: transaction.amount, type: transaction.type, mode: 'full' })}
         </Text>
         <Text size="1" color="gray">
           {transaction.type === 'expense' ? transaction.to : transaction.from}

--- a/src/pages/transaction-list/components/monthly-transaction.tsx
+++ b/src/pages/transaction-list/components/monthly-transaction.tsx
@@ -11,13 +11,13 @@ export const MonthlyTransaction = ({
   return (
     <Flex justify="center" align="center" gap="2">
       <Text size="4" weight="bold" align="center" color="blue">
-        {transactionAmountFormat(monthlyIncome, 'income', 'full')}
+        {transactionAmountFormat({ amount: monthlyIncome, type: 'income', mode: 'full' })}
       </Text>
       <Text size="3" weight="bold" align="center">
         받고
       </Text>
       <Text size="4" weight="bold" align="center" color="red">
-        {transactionAmountFormat(monthlyExpense, 'expense', 'full')}
+        {transactionAmountFormat({ amount: monthlyExpense, type: 'expense', mode: 'full' })}
       </Text>
       <Text size="3" weight="bold" align="center">
         썼어요

--- a/src/pages/transactions/components/transaction-create-form.tsx
+++ b/src/pages/transactions/components/transaction-create-form.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, SegmentedControl, Select, Text, TextArea, TextField, Grid, Card } from '@radix-ui/themes'
+import { Button, Flex, SegmentedControl, Select, Text, TextArea, TextField, Grid, Card, Box } from '@radix-ui/themes'
 import { ELEMENT_SIZE } from '~/constants/style'
 import { WON_UNIT } from '~/constants/unit'
 import { commaNumber, parseCommaNumber } from '~/utils/number-format'
@@ -43,6 +43,7 @@ export const TransactionCreateForm = () => {
               </Button>
             </Flex>
           </Flex>
+          <Box p="2" />
           <Grid columns="5" gap="4">
             <Flex direction="column" gap="2">
               <Label>금액</Label>
@@ -65,7 +66,7 @@ export const TransactionCreateForm = () => {
             </Flex>
 
             <Flex direction="column" gap="2">
-              <Label>지출처</Label>
+              <Label>{type === 'expense' ? '지출처' : '수입처'}</Label>
               <TextField.Root
                 type="text"
                 placeholder={payeePlaceholder}

--- a/src/pages/transactions/components/transaction-list-table-amount-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-amount-cell-editable.tsx
@@ -1,0 +1,62 @@
+import { Text, TextField } from '@radix-ui/themes'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { ELEMENT_SIZE_SMALL } from '~/constants/style'
+import { WON_UNIT } from '~/constants/unit'
+import { useTransactionUpdateMutation } from '~/queries/transactions'
+import { TRANSACTIONS_KEY } from '~/queries/transactions/transactions.model'
+import { parseCommaNumber } from '~/utils/number-format'
+
+export const TransactionListTableAmountCellEditable = ({
+  id,
+  defaultValue,
+  endEdit,
+}: {
+  id: string
+  defaultValue: number
+  endEdit: () => void
+}) => {
+  const queryClient = useQueryClient()
+  const { mutate: updateTransaction } = useTransactionUpdateMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TRANSACTIONS_KEY.default })
+    },
+  })
+
+  const [amount, setAmount] = useState(defaultValue)
+
+  const handleChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) =>
+    setAmount(parseCommaNumber(value))
+
+  const handleBlur = () => {
+    updateTransaction({
+      id,
+      data: {
+        amount,
+      },
+    })
+    endEdit()
+  }
+
+  return (
+    <TextField.Root
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9, ,]*"
+      placeholder="금액을 입력하세요"
+      value={amount}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      size={ELEMENT_SIZE_SMALL}
+      autoFocus={true}
+      required
+    >
+      <TextField.Slot side="right">
+        <Text as="label" size={ELEMENT_SIZE_SMALL} weight="bold">
+          {WON_UNIT}
+        </Text>
+      </TextField.Slot>
+    </TextField.Root>
+  )
+}

--- a/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
@@ -1,0 +1,53 @@
+import { Select } from '@radix-ui/themes'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { SORT_ORDER } from '~/constants/query'
+import { ELEMENT_SIZE_SMALL } from '~/constants/style'
+import { useCategoryListQuery } from '~/queries/category'
+import { useTransactionUpdateMutation } from '~/queries/transactions'
+import { TRANSACTIONS_KEY } from '~/queries/transactions/transactions.model'
+
+interface TransactionListTableCategoryCellEditableProps {
+  id: string
+  defaultValue: number
+  endEdit: () => void
+}
+
+export const TransactionListTableCategoryCellEditable = ({
+  id,
+  defaultValue,
+  endEdit,
+}: TransactionListTableCategoryCellEditableProps) => {
+  const queryClient = useQueryClient()
+  const { mutate: updateTransaction } = useTransactionUpdateMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TRANSACTIONS_KEY.default })
+    },
+  })
+
+  const { data: categoryList } = useCategoryListQuery(SORT_ORDER.ASC)
+
+  const [category, setCategory] = useState(defaultValue)
+
+  const handleValueChange = (value: string) => {
+    setCategory(Number(value))
+    updateTransaction({
+      id,
+      data: { category: category },
+    })
+    endEdit()
+  }
+
+  return (
+    <Select.Root size={ELEMENT_SIZE_SMALL} defaultValue={defaultValue.toString()} onValueChange={handleValueChange}>
+      <Select.Trigger />
+      <Select.Content>
+        {categoryList?.map((category) => (
+          <Select.Item key={category.id} value={category.id.toString()}>
+            {category.name}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  )
+}

--- a/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
@@ -33,7 +33,7 @@ export const TransactionListTableCategoryCellEditable = ({
     setCategory(Number(value))
     updateTransaction({
       id,
-      data: { category: category },
+      data: { category: Number(value) },
     })
     endEdit()
   }

--- a/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-category-cell-editable.tsx
@@ -1,6 +1,5 @@
 import { Select } from '@radix-ui/themes'
 import { useQueryClient } from '@tanstack/react-query'
-import { useState } from 'react'
 import { SORT_ORDER } from '~/constants/query'
 import { ELEMENT_SIZE_SMALL } from '~/constants/style'
 import { useCategoryListQuery } from '~/queries/category'
@@ -27,10 +26,7 @@ export const TransactionListTableCategoryCellEditable = ({
 
   const { data: categoryList } = useCategoryListQuery(SORT_ORDER.ASC)
 
-  const [category, setCategory] = useState(defaultValue)
-
   const handleValueChange = (value: string) => {
-    setCategory(Number(value))
     updateTransaction({
       id,
       data: { category: Number(value) },

--- a/src/pages/transactions/components/transaction-list-table-date-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-date-cell-editable.tsx
@@ -1,0 +1,53 @@
+import { TextField } from '@radix-ui/themes'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { ELEMENT_SIZE_SMALL } from '~/constants/style'
+import { useTransactionUpdateMutation } from '~/queries/transactions'
+import { TRANSACTIONS_KEY } from '~/queries/transactions/transactions.model'
+
+interface TransactionListTableDateCellEditableProps {
+  id: string
+  defaultValue: string
+  endEdit: () => void
+}
+
+export const TransactionListTableDateCellEditable = ({
+  id,
+  defaultValue,
+  endEdit,
+}: TransactionListTableDateCellEditableProps) => {
+  const queryClient = useQueryClient()
+  const { mutate: updateTransaction } = useTransactionUpdateMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TRANSACTIONS_KEY.default })
+    },
+  })
+
+  const [date, setDate] = useState(defaultValue)
+
+  const handleChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => setDate(value)
+
+  const handleBlur = () => {
+    updateTransaction({
+      id,
+      data: {
+        date,
+      },
+    })
+    endEdit()
+  }
+  return (
+    <TextField.Root
+      type="date"
+      placeholder="날짜를 입력하세요"
+      size={ELEMENT_SIZE_SMALL}
+      value={date}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      required
+      autoFocus
+    />
+  )
+}

--- a/src/pages/transactions/components/transaction-list-table-memo-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-memo-cell-editable.tsx
@@ -1,0 +1,57 @@
+import { Flex, Text, TextArea } from '@radix-ui/themes'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { ELEMENT_SIZE_SMALL } from '~/constants/style'
+import { MAX_MEMO_LENGTH } from '~/constants/transaction'
+import { useTransactionUpdateMutation } from '~/queries/transactions'
+import { TRANSACTIONS_KEY } from '~/queries/transactions/transactions.model'
+
+interface TransactionListTableMemoCellEditableProps {
+  id: string
+  defaultValue: string
+  endEdit: () => void
+}
+
+export const TransactionListTableMemoCellEditable = ({
+  id,
+  defaultValue,
+  endEdit,
+}: TransactionListTableMemoCellEditableProps) => {
+  const queryClient = useQueryClient()
+  const { mutate: updateTransaction } = useTransactionUpdateMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TRANSACTIONS_KEY.default })
+    },
+  })
+
+  const [memo, setMemo] = useState(defaultValue)
+
+  const handleChange = ({ target: { value } }: React.ChangeEvent<HTMLTextAreaElement>) => setMemo(value)
+
+  const handleBlur = () => {
+    updateTransaction({
+      id,
+      data: {
+        memo,
+      },
+    })
+    endEdit()
+  }
+  return (
+    <Flex direction="column" gap="2">
+      <TextArea
+        size={ELEMENT_SIZE_SMALL}
+        placeholder="메모를 남겨보세요"
+        value={memo}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        maxLength={MAX_MEMO_LENGTH}
+        autoFocus
+      />
+      <Text size="1" align="right">
+        나만 볼 수 있는 메모 {memo.length}/{MAX_MEMO_LENGTH}
+      </Text>
+    </Flex>
+  )
+}

--- a/src/pages/transactions/components/transaction-list-table-payee-cell-editable.tsx
+++ b/src/pages/transactions/components/transaction-list-table-payee-cell-editable.tsx
@@ -1,0 +1,55 @@
+import { TextField } from '@radix-ui/themes'
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { ELEMENT_SIZE_SMALL } from '~/constants/style'
+import { useTransactionUpdateMutation } from '~/queries/transactions'
+import { TRANSACTIONS_KEY } from '~/queries/transactions/transactions.model'
+
+interface TransactionListTablePayeeCellEditableProps {
+  id: string
+  defaultValue: string
+  type: 'expense' | 'income'
+  endEdit: () => void
+}
+
+export const TransactionListTablePayeeCellEditable = ({
+  id,
+  defaultValue,
+  type,
+  endEdit,
+}: TransactionListTablePayeeCellEditableProps) => {
+  const queryClient = useQueryClient()
+  const { mutate: updateTransaction } = useTransactionUpdateMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TRANSACTIONS_KEY.default })
+    },
+  })
+
+  const [payee, setPayee] = useState(defaultValue)
+
+  const handleChange = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => setPayee(value)
+
+  const handleBlur = () => {
+    updateTransaction({
+      id,
+      data: {
+        ...(type === 'expense' ? { to: payee } : { from: payee }),
+      },
+    })
+    endEdit()
+  }
+
+  return (
+    <TextField.Root
+      type="text"
+      placeholder="거래처를 입력하세요"
+      value={payee}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      size={ELEMENT_SIZE_SMALL}
+      autoFocus={true}
+      required
+    />
+  )
+}

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -8,6 +8,7 @@ import { transactionAmountFormat } from '~/utils/units'
 import { TransactionListTableAmountCellEditable } from './transaction-list-table-amount-cell-editable'
 import { TransactionListTablePayeeCellEditable } from './transaction-list-table-payee-cell-editable'
 import { TransactionListTableCategoryCellEditable } from './transaction-list-table-category-cell-editable'
+import { TransactionListTableMemoCellEditable } from './transaction-list-table-memo-cell-editable'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
@@ -96,5 +97,17 @@ const columns: ColumnDef<Transaction>[] = [
   {
     accessorKey: 'memo',
     header: '메모',
+    cell: ({ row }) => (
+      <Table.EditableCell
+        renderReadOnly={({ startEdit }) => <Text onDoubleClick={startEdit}>{row.original.memo}</Text>}
+        renderEditable={({ endEdit }) => (
+          <TransactionListTableMemoCellEditable
+            id={row.original.id}
+            defaultValue={row.original.memo}
+            endEdit={endEdit}
+          />
+        )}
+      />
+    ),
   },
 ]

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -6,6 +6,7 @@ import { Table } from '~/components/table'
 import { Transaction, useAllTransactionsListQuery } from '~/queries/transactions'
 import { transactionAmountFormat } from '~/utils/units'
 import { TransactionListTableAmountCellEditable } from './transaction-list-table-amount-cell-editable'
+import { TransactionListTablePayeeCellEditable } from './transaction-list-table-payee-cell-editable'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
@@ -47,7 +48,21 @@ const columns: ColumnDef<Transaction>[] = [
   {
     accessorKey: 'payee',
     header: '거래처',
-    cell: ({ row }) => (row.original.type === 'expense' ? row.original.to : row.original.from),
+    cell: ({ row }) => (
+      <Table.EditableCell
+        renderReadOnly={({ startEdit }) => (
+          <Text onDoubleClick={startEdit}>{row.original.type === 'expense' ? row.original.to : row.original.from}</Text>
+        )}
+        renderEditable={({ endEdit }) => (
+          <TransactionListTablePayeeCellEditable
+            id={row.original.id}
+            defaultValue={row.original.type === 'expense' ? row.original.to : row.original.from}
+            type={row.original.type}
+            endEdit={endEdit}
+          />
+        )}
+      />
+    ),
   },
   {
     accessorKey: 'category',

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -9,6 +9,7 @@ import { TransactionListTableAmountCellEditable } from './transaction-list-table
 import { TransactionListTablePayeeCellEditable } from './transaction-list-table-payee-cell-editable'
 import { TransactionListTableCategoryCellEditable } from './transaction-list-table-category-cell-editable'
 import { TransactionListTableMemoCellEditable } from './transaction-list-table-memo-cell-editable'
+import { TransactionListTableDateCellEditable } from './transaction-list-table-date-cell-editable'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
@@ -89,9 +90,16 @@ const columns: ColumnDef<Transaction>[] = [
     accessorKey: 'date',
     header: '거래일자',
     cell: ({ row }) => (
-      <Text size="2" weight="medium">
-        {row.original.date.split('T')[0]}
-      </Text>
+      <Table.EditableCell
+        renderReadOnly={({ startEdit }) => <Text onDoubleClick={startEdit}>{row.original.date.split('T')[0]}</Text>}
+        renderEditable={({ endEdit }) => (
+          <TransactionListTableDateCellEditable
+            id={row.original.id}
+            defaultValue={row.original.date}
+            endEdit={endEdit}
+          />
+        )}
+      />
     ),
   },
   {

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from '@radix-ui/themes'
+import { Box, Flex, Text, Tooltip } from '@radix-ui/themes'
 import { ColumnDef } from '@tanstack/react-table'
 
 import { Table } from '~/components/table'
@@ -10,15 +10,22 @@ import { TransactionListTablePayeeCellEditable } from './transaction-list-table-
 import { TransactionListTableCategoryCellEditable } from './transaction-list-table-category-cell-editable'
 import { TransactionListTableMemoCellEditable } from './transaction-list-table-memo-cell-editable'
 import { TransactionListTableDateCellEditable } from './transaction-list-table-date-cell-editable'
+import { InfoCircledIcon } from '@radix-ui/react-icons'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
 
   return (
     <Flex direction="column" gap="2">
-      <Text size="4" weight="bold">
-        입출금 내역
-      </Text>
+      <Flex align="center" gap="2">
+        <Text size="4" weight="bold">
+          입출금 내역
+        </Text>
+        <Tooltip content="셀을 더블클릭해서 수정할 수 있어요" side="right">
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+
       <Table.Root<Transaction> data={data} columns={columns}>
         <Table.Header />
         <Table.Body />

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -5,6 +5,7 @@ import { Table } from '~/components/table'
 
 import { Transaction, useAllTransactionsListQuery } from '~/queries/transactions'
 import { transactionAmountFormat } from '~/utils/units'
+import { TransactionListTableAmountCellEditable } from './transaction-list-table-amount-cell-editable'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
@@ -27,9 +28,20 @@ const columns: ColumnDef<Transaction>[] = [
     accessorKey: 'amount',
     header: '금액',
     cell: ({ row }) => (
-      <Text weight="medium" color={row.original.type === 'expense' ? undefined : 'blue'}>
-        {transactionAmountFormat(row.original.amount, row.original.type, 'short')}
-      </Text>
+      <Table.EditableCell
+        renderReadOnly={({ startEdit }) => (
+          <Text weight="medium" color={row.original.type === 'expense' ? undefined : 'blue'} onDoubleClick={startEdit}>
+            {transactionAmountFormat(row.original.amount, row.original.type, 'short')}
+          </Text>
+        )}
+        renderEditable={({ endEdit }) => (
+          <TransactionListTableAmountCellEditable
+            id={row.original.id}
+            defaultValue={row.original.amount}
+            endEdit={endEdit}
+          />
+        )}
+      />
     ),
   },
   {

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -31,7 +31,7 @@ const columns: ColumnDef<Transaction>[] = [
       <Table.EditableCell
         renderReadOnly={({ startEdit }) => (
           <Text weight="medium" color={row.original.type === 'expense' ? undefined : 'blue'} onDoubleClick={startEdit}>
-            {transactionAmountFormat(row.original.amount, row.original.type, 'short')}
+            {transactionAmountFormat({ amount: row.original.amount, type: row.original.type, mode: 'full' })}
           </Text>
         )}
         renderEditable={({ endEdit }) => (
@@ -45,7 +45,7 @@ const columns: ColumnDef<Transaction>[] = [
     ),
   },
   {
-    accessorKey: 'counterpart',
+    accessorKey: 'payee',
     header: '거래처',
     cell: ({ row }) => (row.original.type === 'expense' ? row.original.to : row.original.from),
   },

--- a/src/pages/transactions/components/transaction-list-table.tsx
+++ b/src/pages/transactions/components/transaction-list-table.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@radix-ui/themes'
+import { Box, Flex, Text } from '@radix-ui/themes'
 import { ColumnDef } from '@tanstack/react-table'
 
 import { Table } from '~/components/table'
@@ -7,6 +7,7 @@ import { Transaction, useAllTransactionsListQuery } from '~/queries/transactions
 import { transactionAmountFormat } from '~/utils/units'
 import { TransactionListTableAmountCellEditable } from './transaction-list-table-amount-cell-editable'
 import { TransactionListTablePayeeCellEditable } from './transaction-list-table-payee-cell-editable'
+import { TransactionListTableCategoryCellEditable } from './transaction-list-table-category-cell-editable'
 
 export const TransactionListTable = () => {
   const { data } = useAllTransactionsListQuery()
@@ -51,7 +52,9 @@ const columns: ColumnDef<Transaction>[] = [
     cell: ({ row }) => (
       <Table.EditableCell
         renderReadOnly={({ startEdit }) => (
-          <Text onDoubleClick={startEdit}>{row.original.type === 'expense' ? row.original.to : row.original.from}</Text>
+          <Box width="100%" height="100%" onDoubleClick={startEdit}>
+            <Text>{row.original.type === 'expense' ? row.original.to : row.original.from}</Text>
+          </Box>
         )}
         renderEditable={({ endEdit }) => (
           <TransactionListTablePayeeCellEditable
@@ -68,6 +71,18 @@ const columns: ColumnDef<Transaction>[] = [
     accessorKey: 'category',
     accessorFn: (row) => row.category.name,
     header: '카테고리',
+    cell: ({ row }) => (
+      <Table.EditableCell
+        renderReadOnly={({ startEdit }) => <Text onDoubleClick={startEdit}>{row.original.category.name}</Text>}
+        renderEditable={({ endEdit }) => (
+          <TransactionListTableCategoryCellEditable
+            id={row.original.id}
+            defaultValue={Number(row.original.category.id)}
+            endEdit={endEdit}
+          />
+        )}
+      />
+    ),
   },
   {
     accessorKey: 'date',

--- a/src/queries/transactions/transactions.api.ts
+++ b/src/queries/transactions/transactions.api.ts
@@ -13,8 +13,9 @@ export const useTransactionsListQuery = (
 ) =>
   useSuspenseQuery<Transaction[]>({
     queryKey: TRANSACTIONS_KEY.list(year, month, sortOrder),
-    queryFn: () => request(TRANSACTIONS_ENDPOINT.list(year, month, sortOrder)),
+    queryFn: () => request(TRANSACTIONS_ENDPOINT.list(year, month, sortOrder, 'expense')),
   })
+
 export const useAllTransactionsListQuery = () =>
   // TODO: useTransactionsListQuery 리팩토링 후 삭제
   useSuspenseQuery<Transaction[]>({
@@ -29,6 +30,7 @@ export const useTransactionDetailQuery = (transactionId: string) =>
   })
 
 type TransactionCreatePayload = z.infer<typeof TransactionCreateSchema>
+
 export const useTransactionCreateMutation = () => {
   return useMutation<void, Error, TransactionCreatePayload>({
     mutationFn: (data) =>
@@ -40,6 +42,7 @@ export const useTransactionCreateMutation = () => {
 }
 
 type TransactionUpdatePayload = { id: string; data: z.infer<typeof TransactionUpdateSchema> }
+
 export const useTransactionUpdateMutation = (options?: MutationOptions<void, Error, TransactionUpdatePayload>) => {
   return useMutation<void, Error, TransactionUpdatePayload>({
     mutationFn: (payload) => request(TRANSACTIONS_ENDPOINT.update(payload.id), { method: 'PATCH', data: payload.data }),

--- a/src/queries/transactions/transactions.api.ts
+++ b/src/queries/transactions/transactions.api.ts
@@ -1,7 +1,7 @@
 import { MutationOptions, useMutation, useSuspenseQuery } from '@tanstack/react-query'
 
 import { TRANSACTIONS_ENDPOINT, TRANSACTIONS_KEY } from './transactions.model'
-import { Transaction, transactionCreateSchema, transactionUpdateSchema } from './transactions.type'
+import { Transaction, TransactionCreateSchema, TransactionUpdateSchema } from './transactions.type'
 import { request } from '~/utils/request'
 import { SortOrder } from '~/types/query.type'
 import { z } from 'zod'
@@ -28,7 +28,7 @@ export const useTransactionDetailQuery = (transactionId: string) =>
     queryFn: () => request(TRANSACTIONS_ENDPOINT.detail(transactionId)),
   })
 
-type TransactionCreatePayload = z.infer<typeof transactionCreateSchema>
+type TransactionCreatePayload = z.infer<typeof TransactionCreateSchema>
 export const useTransactionCreateMutation = () => {
   return useMutation<void, Error, TransactionCreatePayload>({
     mutationFn: (data) =>
@@ -39,7 +39,7 @@ export const useTransactionCreateMutation = () => {
   })
 }
 
-type TransactionUpdatePayload = { id: string; data: z.infer<typeof transactionUpdateSchema> }
+type TransactionUpdatePayload = { id: string; data: z.infer<typeof TransactionUpdateSchema> }
 export const useTransactionUpdateMutation = (options?: MutationOptions<void, Error, TransactionUpdatePayload>) => {
   return useMutation<void, Error, TransactionUpdatePayload>({
     mutationFn: (payload) => request(TRANSACTIONS_ENDPOINT.update(payload.id), { method: 'PATCH', data: payload.data }),

--- a/src/queries/transactions/transactions.api.ts
+++ b/src/queries/transactions/transactions.api.ts
@@ -1,9 +1,10 @@
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query'
+import { MutationOptions, useMutation, useSuspenseQuery } from '@tanstack/react-query'
 
 import { TRANSACTIONS_ENDPOINT, TRANSACTIONS_KEY } from './transactions.model'
-import { Transaction, TransactionMutationPayload } from './transactions.type'
+import { Transaction, transactionCreateSchema, transactionUpdateSchema } from './transactions.type'
 import { request } from '~/utils/request'
 import { SortOrder } from '~/types/query.type'
+import { z } from 'zod'
 
 export const useTransactionsListQuery = (
   year: number,
@@ -27,25 +28,27 @@ export const useTransactionDetailQuery = (transactionId: string) =>
     queryFn: () => request(TRANSACTIONS_ENDPOINT.detail(transactionId)),
   })
 
+type TransactionCreatePayload = z.infer<typeof transactionCreateSchema>
 export const useTransactionCreateMutation = () => {
-  return useMutation<void, Error, TransactionMutationPayload>({
+  return useMutation<void, Error, TransactionCreatePayload>({
     mutationFn: (data) =>
       request(TRANSACTIONS_ENDPOINT.default, {
         method: 'POST',
-        data: JSON.stringify(data),
+        data,
       }),
   })
 }
 
-export const useTransactionUpdateMutation = (transactionId: string) => {
-  return useMutation<void, Error, TransactionMutationPayload>({
-    mutationFn: (data) =>
-      request(TRANSACTIONS_ENDPOINT.update(transactionId), { method: 'PATCH', data: JSON.stringify(data) }),
+type TransactionUpdatePayload = { id: string; data: z.infer<typeof transactionUpdateSchema> }
+export const useTransactionUpdateMutation = (options?: MutationOptions<void, Error, TransactionUpdatePayload>) => {
+  return useMutation<void, Error, TransactionUpdatePayload>({
+    mutationFn: (payload) => request(TRANSACTIONS_ENDPOINT.update(payload.id), { method: 'PATCH', data: payload.data }),
+    ...options,
   })
 }
 
-export const useTransactionDeleteMutation = (transactionId: string) => {
-  return useMutation<void>({
-    mutationFn: () => request(TRANSACTIONS_ENDPOINT.update(transactionId), { method: 'DELETE' }),
+export const useTransactionDeleteMutation = () => {
+  return useMutation<void, Error, string>({
+    mutationFn: (transactionId) => request(TRANSACTIONS_ENDPOINT.update(transactionId), { method: 'DELETE' }),
   })
 }

--- a/src/queries/transactions/transactions.model.ts
+++ b/src/queries/transactions/transactions.model.ts
@@ -4,10 +4,10 @@ export const TRANSACTIONS_ENDPOINT = {
   default: '/transactions',
   all: ({ sortOrder }: { sortOrder?: SortOrder }) =>
     `${TRANSACTIONS_ENDPOINT.default}?select=*,category:categories(*)&order=date.${sortOrder}`,
-  list: (year: number, month: number, sortOrder: SortOrder) => {
+  list: (year: number, month: number, sortOrder: SortOrder, type?: string) => {
     const startDate = `${year}-${month.toString().padStart(2, '0')}-01`
     const endDate = `${year}-${month.toString().padStart(2, '0')}-${new Date(year, month, 0).getDate()}`
-    return `${TRANSACTIONS_ENDPOINT.default}?select=*,category:categories(*)&date=gte.${startDate}&date=lte.${endDate}&order=date.${sortOrder}`
+    return `${TRANSACTIONS_ENDPOINT.default}?select=*,category:categories(*)&date=gte.${startDate}&date=lte.${endDate}&order=date.${sortOrder}&type=eq.${type}`
   },
   detail: (transactionId: string) => {
     return `${TRANSACTIONS_ENDPOINT.default}?id=eq.${transactionId}&select=*,category:categories(*)&limit=1`

--- a/src/queries/transactions/transactions.type.ts
+++ b/src/queries/transactions/transactions.type.ts
@@ -42,12 +42,15 @@ export type OptionalInfo = z.infer<typeof optionalInfoSchema>
 type TransactionBaseType = Omit<RequiredInfo, 'payee'> & OptionalInfo
 
 export interface TransactionMutationPayload extends TransactionBaseType {
-  from?: string
-  to?: string
+  id: string
+  data: {
+    from?: string
+    to?: string
+  }
 }
 
 // FIXME: 스키마 타입 단순화 필요. 위의 타입들 추후 없애기
-// 기본적으로 상태로 다룰 타입을 스키마로 정의하고 실제 요청 타입은 스키마를 확장하여 정의 => 그래야 유효성 검사 쉬워짐
+// 기본적으로 요청에 보낼 타입을 스키마로 정의하고 각 컴포넌트의 상태는 infer로 다루기. 유효성 검사할 때는 요청 타입에 맞게 변환 필요
 export const transactionCreateSchema = z.object({
   type: z.enum([TRANSACTION_TYPE.INCOME, TRANSACTION_TYPE.EXPENSE]),
   amount: z.number().positive().max(1000000000, '너무 큰 금액입니다.').min(1, '최소 1원 이상 입력해주세요'),
@@ -55,4 +58,16 @@ export const transactionCreateSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}/, '올바른 날짜를 입력해주세요'),
   category: z.number().min(1),
   memo: z.string().max(60, '최대 60자까지 입력 가능합니다.'),
+})
+
+export const transactionUpdateSchema = z.object({
+  type: z.enum([TRANSACTION_TYPE.INCOME, TRANSACTION_TYPE.EXPENSE]).optional(),
+  amount: z.number().max(1000000000, '너무 큰 금액입니다.').min(1, '최소 1원 이상 입력해주세요').optional(),
+  payee: z.string().optional(),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}/, '올바른 날짜를 입력해주세요')
+    .optional(),
+  category: z.number().min(1).optional(),
+  memo: z.string().max(60, '최대 60자까지 입력 가능합니다.').optional(),
 })

--- a/src/queries/transactions/transactions.type.ts
+++ b/src/queries/transactions/transactions.type.ts
@@ -39,31 +39,34 @@ export type TransactionFormData = z.infer<typeof transactionFormSchema>
 export type RequiredInfo = z.infer<typeof requiredInfoSchema>
 export type OptionalInfo = z.infer<typeof optionalInfoSchema>
 
-type TransactionBaseType = Omit<RequiredInfo, 'payee'> & OptionalInfo
-
-export interface TransactionMutationPayload extends TransactionBaseType {
-  id: string
-  data: {
-    from?: string
-    to?: string
-  }
-}
-
 // FIXME: 스키마 타입 단순화 필요. 위의 타입들 추후 없애기
 // 기본적으로 요청에 보낼 타입을 스키마로 정의하고 각 컴포넌트의 상태는 infer로 다루기. 유효성 검사할 때는 요청 타입에 맞게 변환 필요
-export const transactionCreateSchema = z.object({
-  type: z.enum([TRANSACTION_TYPE.INCOME, TRANSACTION_TYPE.EXPENSE]),
+const BaseTransactionCreateSchema = z.object({
   amount: z.number().positive().max(1000000000, '너무 큰 금액입니다.').min(1, '최소 1원 이상 입력해주세요'),
-  payee: z.string().min(1, '필수 입력 항목입니다.'),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}/, '올바른 날짜를 입력해주세요'),
   category: z.number().min(1),
   memo: z.string().max(60, '최대 60자까지 입력 가능합니다.'),
 })
 
-export const transactionUpdateSchema = z.object({
+const ExpenseCreateSchema = BaseTransactionCreateSchema.extend({
+  type: z.literal(TRANSACTION_TYPE.EXPENSE),
+  to: z.string().min(1, '필수 입력 항목입니다.'),
+  from: z.string().optional(),
+})
+
+const IncomeCreateSchema = BaseTransactionCreateSchema.extend({
+  type: z.literal(TRANSACTION_TYPE.INCOME),
+  from: z.string().min(1, '필수 입력 항목입니다.'),
+  to: z.string().optional(),
+})
+
+export const TransactionCreateSchema = z.discriminatedUnion('type', [ExpenseCreateSchema, IncomeCreateSchema])
+
+export const TransactionUpdateSchema = z.object({
   type: z.enum([TRANSACTION_TYPE.INCOME, TRANSACTION_TYPE.EXPENSE]).optional(),
   amount: z.number().max(1000000000, '너무 큰 금액입니다.').min(1, '최소 1원 이상 입력해주세요').optional(),
-  payee: z.string().optional(),
+  from: z.string().min(1, '필수 항목 입니다.').optional(),
+  to: z.string().min(1, '필수 항목 입니다.').optional(),
   date: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}/, '올바른 날짜를 입력해주세요')

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,5 +1,11 @@
 import { WON_UNIT } from '~/constants/unit'
 
-export function transactionAmountFormat(amount: number, type: 'expense' | 'income', mode: 'full' | 'short') {
+type TransactionAmountFormatArgs = {
+  amount: number
+  type: 'expense' | 'income'
+  mode?: 'full' | 'short'
+}
+
+export function transactionAmountFormat({ amount, type, mode = 'short' }: TransactionAmountFormatArgs) {
   return `${type === 'expense' ? '-' : '+'}${amount.toLocaleString()}${mode === 'full' ? WON_UNIT : ''}`
 }


### PR DESCRIPTION
## 연관 이슈
#21 
## 내용
- [x] 제목, 카테고리, 거래처 등 테이블을 더블클릭하여 즉시 수정 할 수 있는 셀 추가
- [x] 이를 위한 editable cell 컴포넌트를 table 컴포넌트에 추가
- [x] 더블클릭하면 수정가능하다는 가이드를 테이블에 표시